### PR TITLE
Add PCA benchmarks

### DIFF
--- a/daal4py/pca.py
+++ b/daal4py/pca.py
@@ -1,0 +1,145 @@
+# Copyright (C) 2017-2019 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+from __future__ import print_function
+import numpy as np
+import timeit
+from numpy.random import rand
+from daal4py import pca, pca_transform, normalization_zscore
+from daal4py.sklearn.utils import getFPType
+from sklearn.utils.extmath import svd_flip
+from args import getArguments, coreString
+from bench import prepare_benchmark
+
+import argparse
+parser = argparse.ArgumentParser(description='daal4py PCA benchmark')
+parser.add_argument('--svd-solver', type=str, choices=['daal', 'full'],
+                    default='daal', help='SVD solver to use')
+parser.add_argument('--n-components', type=int, default=None,
+                    help='Number of components to find')
+parser.add_argument('--whiten', action='store_true', default=False,
+                    help='Perform whitening')
+parser.add_argument('--write-results', action='store_true', default=False,
+                    help='Write results to disk for verification')
+args = getArguments(parser)
+REP = args.iteration if args.iteration != '?' else 10
+core_number, daal_version = prepare_benchmark(args)
+
+
+def st_time(func):
+    def st_func(*args, **keyArgs):
+        times = []
+        for n in range(REP):
+            t1 = timeit.default_timer()
+            r = func(*args, **keyArgs)
+            t2 = timeit.default_timer()
+            times.append(t2-t1)
+        print(min(times))
+        return r
+    return st_func
+
+p = args.size[0]
+n = args.size[1]
+X = rand(p,n)
+Xp = rand(p,n)
+
+if args.n_components:
+    n_components = args.n_components
+else:
+    n_components = min((n, (2 + min((n, p))) // 3))
+
+def pca_fit_daal(X, n_components):
+
+    if n_components < 1:
+        n_components = min(X.shape)
+
+    fptype = getFPType(X)
+
+    centering_algo = normalization_zscore(
+            fptype=fptype,
+            doScale=False
+    )
+
+    pca_algorithm = pca(
+            fptype=fptype,
+            method='svdDense',
+            normalization=centering_algo,
+            resultsToCompute='mean|variance|eigenvalue',
+            isDeterministic=True,
+            nComponents=n_components
+    )
+
+    pca_result = pca_algorithm.compute(X)
+    eigenvectors = pca_result.eigenvectors
+    eigenvalues = pca_result.eigenvalues.ravel()
+    singular_values = np.sqrt((X.shape[0] - 1) * eigenvalues)
+
+    return pca_result, eigenvalues, eigenvectors, singular_values
+
+
+def pca_transform_daal(pca_result, X, n_components, fit_n_samples,
+                       eigenvalues, eigenvectors,
+                       whiten=False, scale_eigenvalues=False):
+
+    fptype = getFPType(X)
+
+    tr_data = {}
+    tr_data['mean'] = pca_result.dataForTransform['mean']
+
+    if whiten:
+        if scale_eigenvalues:
+            tr_data['eigenvalue'] = (fit_n_samples - 1) * pca_result.eigenvalues
+        else:
+            tr_data['eigenvalue'] = pca_result.eigenvalues
+    elif scale_eigenvalues:
+        tr_data['eigenvalue'] = np.full((1, pca_result.eigenvalues.size),
+                                        fit_n_samples - 1, dtype=X.dtype)
+
+    transform_algorithm = pca_transform(fptype=fptype, nComponents=n_components)
+    transform_result = transform_algorithm.compute(X, pca_result.eigenvectors, tr_data)
+    return transform_result.transformedData
+
+
+def pca_fit_full_daal(X, n_components):
+
+    fit_result, eigenvalues, eigenvectors, S = pca_fit_daal(X, min(X.shape))
+    U = pca_transform_daal(fit_result, X, min(X.shape), X.shape[0],
+                           eigenvalues, eigenvectors,
+                           whiten=True, scale_eigenvalues=True)
+    V = fit_result.eigenvectors
+
+    U, V = svd_flip(U, V)
+
+    eigenvalues = fit_result.eigenvalues[:n_components].copy()
+    eigenvectors = fit_result.eigenvectors[:n_components].copy()
+
+    return fit_result, eigenvalues, eigenvectors, U, S, V
+
+
+@st_time
+def test_fit(X):
+    if args.svd_solver == 'full':
+        return pca_fit_full_daal(X, n_components)
+    else:
+        return pca_fit_daal(X, n_components)
+
+@st_time
+def test_transform(Xp, pca_result, eigenvalues, eigenvectors):
+    return pca_transform_daal(pca_result, Xp, n_components, X.shape[0],
+                              eigenvalues, eigenvectors,
+                              whiten=args.whiten)
+
+
+print (','.join([args.batchID, args.arch, args.prefix, "PCA.fit", coreString(args.num_threads), "Double", "%sx%s" % (p,n)]), end=',')
+res = test_fit(X)
+print (','.join([args.batchID, args.arch, args.prefix, "PCA.transform", coreString(args.num_threads), "Double", "%sx%s" % (p,n)]), end=',')
+tr = test_transform(Xp, res[0], res[1], res[2])
+
+
+if args.write_results:
+    np.save('pca_daal4py_X.npy', X)
+    np.save('pca_daal4py_Xp.npy', Xp)
+    np.save('pca_daal4py_eigvals.npy', res[1])
+    np.save('pca_daal4py_eigvecs.npy', res[2])
+    np.save('pca_daal4py_tr.npy', tr)

--- a/native/common.hpp
+++ b/native/common.hpp
@@ -163,6 +163,35 @@ void write_table(dm::NumericTablePtr table,
 
 
 /*
+ * Create a new HomogenNumericTable from a submatrix of an existing
+ * HomogenNumericTable.
+ */
+template <typename T>
+dm::NumericTablePtr
+copy_submatrix(dm::NumericTablePtr src,
+               size_t row, size_t col, size_t rows, size_t cols) {
+
+    dm::BlockDescriptor<T> block;
+    src->getBlockOfRows(0, src->getNumberOfRows(), dm::readOnly, block);
+    T *srcdata = block.getBlockPtr();
+
+    dm::NumericTablePtr dest = dm::HomogenNumericTable<T>::create(
+            cols, rows, dm::NumericTable::doAllocate);
+    dest->getBlockOfRows(0, dest->getNumberOfRows(), dm::readWrite, block);
+    T *destdata = block.getBlockPtr();
+
+    for (int i = 0; i < rows; i++) {
+        for (int j = 0; j < cols; j++) {
+            destdata[i*cols + j] = srcdata[(i+col)*cols + j+row];
+        }
+    }
+
+    return dest;
+
+}
+
+
+/*
  * Generate an array of random numbers.
  */
 double *gen_random(size_t n) {

--- a/native/common.hpp
+++ b/native/common.hpp
@@ -145,7 +145,7 @@ void write_table(dm::NumericTablePtr table,
     table->getBlockOfRows(0, table->getNumberOfRows(), dm::readOnly, block);
     T *data = block.getBlockPtr();
 
-    size_t shape[] = {table->getNumberOfRows(), table->getNumberOfColumns()};
+    size_t shape[2] = {table->getNumberOfRows(), table->getNumberOfColumns()};
 
     char *c_descr = new char[descr.size() + 1];
     strcpy(c_descr, descr.c_str());
@@ -167,15 +167,22 @@ void write_table(dm::NumericTablePtr table,
 /*
  * Create a new HomogenNumericTable from a submatrix of an existing
  * HomogenNumericTable.
+ *
+ * equivalent in python:
+ *   return src[row_start:row_end, col_start:col_end].copy()
  */
 template <typename T>
 dm::NumericTablePtr
 copy_submatrix(dm::NumericTablePtr src,
-               size_t row, size_t col, size_t rows, size_t cols) {
+               size_t row_start, size_t row_end,
+               size_t col_start, size_t col_end) {
 
     dm::BlockDescriptor<T> srcblock;
     src->getBlockOfRows(0, src->getNumberOfRows(), dm::readOnly, srcblock);
     T *srcdata = srcblock.getBlockPtr();
+
+    size_t cols = col_end - col_start;
+    size_t rows = row_end - row_start;
 
     dm::NumericTablePtr dest = dm::HomogenNumericTable<T>::create(
             cols, rows, dm::NumericTable::doAllocate);
@@ -185,7 +192,7 @@ copy_submatrix(dm::NumericTablePtr src,
 
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {
-            destdata[i*cols + j] = srcdata[(i+col)*cols + j+row];
+            destdata[i*cols + j] = srcdata[(i+col_start)*cols + j+row_start];
         }
     }
 

--- a/native/common.hpp
+++ b/native/common.hpp
@@ -7,6 +7,7 @@
 
 #include "CLI11.hpp"
 #include "daal.h"
+#include "npyfile.h"
 
 namespace dm = daal::data_management;
 namespace ds = daal::services;
@@ -129,6 +130,34 @@ template <typename T>
 dm::NumericTablePtr make_table(T *data, size_t rows, size_t cols) {
 
     return dm::HomogenNumericTable<T>::create(data, cols, rows);
+
+}
+
+
+/*
+ * Write a NumericTable to npy format.
+ */
+template <typename T>
+void write_table(dm::NumericTablePtr table,
+                 const std::string descr, const std::string fn) {
+
+    dm::BlockDescriptor<T> block;
+    table->getBlockOfRows(0, table->getNumberOfRows(), dm::readOnly, block);
+    T *data = block.getBlockPtr();
+
+    size_t shape[] = {table->getNumberOfRows(), table->getNumberOfColumns()};
+
+    char *c_descr = new char[descr.size() + 1];
+    strcpy(c_descr, descr.c_str());
+    const struct npyarr arr {
+        .descr = c_descr,
+        .fortran_order = false,
+        .shape_len = 2,
+        .shape = shape,
+        .data = data
+    };
+
+    save_npy(&arr, fn.c_str(), sizeof(T));
 
 }
 

--- a/native/pca_bench.cpp
+++ b/native/pca_bench.cpp
@@ -108,8 +108,8 @@ da::pca::transform::ResultPtr pca_transform_daal(
     dm::KeyValueDataCollection *new_map_p = new dm::KeyValueDataCollection;
     dm::KeyValueDataCollectionPtr new_map {new_map_p};
     dm::KeyValueDataCollectionPtr old_map = pca_result->get(da::pca::dataForTransform);
-    (*new_map)[da::pca::means] = (*old_map)[da::pca::means];
-    (*new_map)[da::pca::eigenvalues] = pca_eigvals;
+    (*new_map)[da::pca::mean] = (*old_map)[da::pca::mean];
+    (*new_map)[da::pca::eigenvalue] = pca_eigvals;
     
     // time to call DAAL algorithm.
     transform_algorithm.input.set(da::pca::transform::data,

--- a/native/pca_bench.cpp
+++ b/native/pca_bench.cpp
@@ -1,0 +1,354 @@
+/*
+ * Copyright (C) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include <iostream>
+#include <chrono>  
+
+#include "common.hpp"
+#include "daal.h"
+
+
+std::pair<da::pca::ResultPtr, dm::NumericTablePtr>
+pca_fit_daal(double *X, size_t rows, size_t cols, size_t n_components) {
+
+    // Find number of components to use in DAAL
+    if (n_components < 1) {
+        n_components = std::min(n_components, rows);
+    }
+
+    da::pca::Batch<double, da::pca::svdDense> pca_algorithm;
+
+    pca_algorithm.input.set(da::pca::data, make_table(X, rows, cols));
+    pca_algorithm.parameter.resultsToCompute = 
+        da::pca::mean | da::pca::variance | da::pca::eigenvalue;
+    pca_algorithm.parameter.isDeterministic = true;
+    pca_algorithm.parameter.nComponents = n_components;
+    // method svdDense is specified in the template parameters for the
+    // pca::Batch algorithm, and normalization zscore is the default.
+
+    pca_algorithm.compute();
+    da::pca::ResultPtr pca_result = pca_algorithm.getResult();
+
+    // Compute singular values
+    dm::NumericTablePtr eigenvalues = pca_result->get(da::pca::eigenvalues);
+    dm::BlockDescriptor<double> block;
+    eigenvalues->getBlockOfRows(0, eigenvalues->getNumberOfRows(), dm::readOnly, block);
+    double *eigenvalues_arr = block.getBlockPtr();
+
+    size_t s_diag_size = eigenvalues->getNumberOfRows() * eigenvalues->getNumberOfColumns();
+    double *singular_values_arr = new double[s_diag_size];
+
+    for (int i = 0; i < s_diag_size; i++) {
+        singular_values_arr[i] = sqrt((rows - 1) * eigenvalues_arr[i]);
+    }
+
+    dm::NumericTablePtr singular_values = make_table(
+            singular_values_arr,
+            eigenvalues->getNumberOfRows(),
+            eigenvalues->getNumberOfColumns());
+    
+    return std::make_pair(pca_result, singular_values);
+
+}
+
+
+da::pca::transform::ResultPtr pca_transform_daal(
+        da::pca::ResultPtr pca_result,
+        double *X, size_t rows, size_t cols, int n_components,
+        bool whiten, bool scale_eigenvalues) {
+
+    da::pca::transform::Batch<double> transform_algorithm;
+    dm::NumericTablePtr pca_eigvals = pca_result->get(da::pca::eigenvalues);
+    double *new_eigvals;
+    bool need_to_free_pca_eigvals = false;
+    
+    // sklearn scales eigenvalues before whitening operation...
+    if (scale_eigenvalues) {
+        dm::BlockDescriptor<double> block;
+        pca_eigvals->getBlockOfRows(0, pca_eigvals->getNumberOfRows(), dm::readOnly, block);
+        double *eigvals = block.getBlockPtr();
+        size_t eigrows = pca_eigvals->getNumberOfRows();
+        size_t eigcols = pca_eigvals->getNumberOfColumns();
+        size_t arrsize = eigrows * eigcols;
+        new_eigvals = new double[arrsize];
+        need_to_free_pca_eigvals = true;
+        if (whiten) {
+            for (int i = 0; i < arrsize; i++) {
+                new_eigvals[i] = (rows - 1) * new_eigvals[i];
+            }
+        } else {
+            for (int i = 0; i < arrsize; i++) {
+                new_eigvals[i] = rows - 1;
+            }
+        }
+        pca_eigvals = make_table(new_eigvals, eigrows, eigcols);
+    }
+    
+    // time to call DAAL algorithm.
+    transform_algorithm.input.set(da::pca::transform::data,
+                                  make_table(X, rows, cols));
+    transform_algorithm.input.set(da::pca::transform::eigenvectors,
+                                  pca_result->get(da::pca::eigenvectors));
+    transform_algorithm.input.set(da::pca::transform::dataForTransform,
+                                  pca_result->get(da::pca::dataForTransform));
+    transform_algorithm.parameter.nComponents = n_components;
+
+    transform_algorithm.compute();
+
+    if (need_to_free_pca_eigvals) delete new_eigvals;
+
+    return transform_algorithm.getResult();
+
+}
+
+
+/*
+ * Equivalent to sklearn.util.extmath.svd_flip with u_based_decision=True.
+ */
+void svd_flip(dm::NumericTablePtr U, dm::NumericTablePtr V) {
+
+    int u_rows = U->getNumberOfRows();
+    int u_cols = V->getNumberOfColumns();
+    int v_rows = V->getNumberOfRows();
+    int v_cols = V->getNumberOfColumns();
+
+    double *u, *v;
+    dm::BlockDescriptor<double> block;
+    U->getBlockOfRows(0, u_rows, dm::readWrite, block);
+    u = block.getBlockPtr();
+    V->getBlockOfRows(0, v_rows, dm::readWrite, block);
+    v = block.getBlockPtr();
+    
+
+    // for each column in u...
+    for (int i = 0; i < u_cols; i++) {
+        // find the maximum absolute value...
+        double absmax = 0.0;
+        for (int j = 0; j < u_rows; j++) {
+            double curr = u[j*u_cols + i];
+            if (curr > absmax) {
+                absmax = curr;
+            }
+        }
+
+        // now, scale this column of u and same-indexed ROW of v
+        // by the sign of absmax.
+        if (absmax < 0) {
+            for (int j = 0; j < u_rows; j++) {
+                u[j*u_cols + i] = -u[j*u_cols + i];
+            }
+            
+            for (int j = 0; j < v_cols; j++) {
+                v[j + i*v_rows] = -v[j + i*v_rows];
+            }
+        }
+    }
+
+}
+
+
+/**
+ * equivalent to _fit_full_daal.
+ *
+ * Returns U, S, V in the SVD.
+ */
+std::tuple<da::pca::ResultPtr, dm::NumericTablePtr, dm::NumericTablePtr, dm::NumericTablePtr>
+pca_fit_full_daal(double *X, size_t rows, size_t cols, size_t n_components) {
+
+    // Run full decomposition...
+    size_t full_n_components = std::min(rows, cols);
+    da::pca::ResultPtr pca_result;
+    dm::NumericTablePtr singular_values;
+    std::tie(pca_result, singular_values) = pca_fit_daal(X, rows, cols, full_n_components);
+
+    da::pca::transform::ResultPtr transform_result;
+    transform_result = pca_transform_daal(pca_result, X, rows, cols, full_n_components, true, true);
+
+    dm::NumericTablePtr U = transform_result->get(da::pca::transform::transformedData);
+    dm::NumericTablePtr V = pca_result->get(da::pca::eigenvectors);
+
+    // Flip signs to make largest row values positive for each column in U.
+    svd_flip(U, V);
+
+    return std::make_tuple(pca_result, U, singular_values, V);
+
+}
+
+
+/*
+ * Function to time for native equivalent to sklearn PCA.fit.
+ *
+ * Parameters
+ * ----------
+ * X : double *
+ *     input matrix
+ * rows : size_t
+ *     number of rows in input matrix
+ * cols : size_t
+ *     number of columns in input matrix
+ * svd_solver : char
+ *     svd solver to use
+ *     'a' (auto) = automatically pick
+ *     'f' (full) = run full SVD
+ *     'k' (arpack) = not implemented
+ *     'r' (randomized) = not implemented
+ *     'd' (daal) = use daal solver
+ * n_components : size_t
+ *     number of components to retain
+ *
+ * Returns
+ * -------
+ * pca_result, U, S, V
+ *     U, S, V for full fit, pca_result for daal fit
+ */
+std::tuple<da::pca::ResultPtr, dm::NumericTablePtr, dm::NumericTablePtr, dm::NumericTablePtr>
+pca_fit_test(double *X, size_t rows, size_t cols,
+             char svd_solver, size_t n_components) {
+
+    // Skip input validation that sklearn does (we disable it in sklearn benchesa)
+    // n_components is given, don't need to worry about it being None...
+
+    if (svd_solver == 'a') {
+        // Automatically picking SVD solver using same logic as sklearn.
+        // TODO n_components = 'mle'?
+        if (std::max(rows, cols) <= 500) {
+            svd_solver = 'f';
+        } else if (n_components >= 1 && n_components < std::min(rows, cols) * 8 / 10) {
+            svd_solver = 'r';
+        } else {
+            svd_solver = 'f';
+        }
+    }
+
+    da::pca::ResultPtr pca_result;
+    dm::NumericTablePtr U, S, V;
+    U = S = V = make_table(X, 0, 0);
+    switch (svd_solver) {
+        case 'd':
+            std::tie(pca_result, S) = pca_fit_daal(X, rows, cols, n_components);
+            break;
+        case 'f':
+            std::tie(pca_result, U, S, V) = pca_fit_full_daal(X, rows, cols, n_components);
+            break;
+        default:
+            std::cerr << "Unsupported svd_solver='" << svd_solver << '\''
+                << std::endl;
+            std::exit(1);
+    }
+
+    return std::make_tuple(pca_result, U, S, V);
+
+}
+
+
+da::pca::transform::ResultPtr
+pca_transform_test(da::pca::ResultPtr pca_result,
+                   double *X, size_t rows, size_t cols,
+                   int n_components) {
+
+    return pca_transform_daal(pca_result, X, rows, cols, n_components, false, false);
+
+}
+
+
+int main(int argc, char *argv[]) {
+
+    CLI::App app("Native benchmark for Intel(R) DAAL principal component analysis");
+
+    std::string batch, arch, prefix;
+    int num_threads;
+    bool header, verbose;
+    add_common_args(app, batch, arch, prefix, num_threads, header, verbose);
+
+    std::string stringSize = "1000000x50";
+    app.add_option("-s,--size", stringSize, "Problem size");
+
+    int fit_samples = 1;
+    app.add_option("--fit-samples", fit_samples,
+                   "Number of samples to report (fit)");
+
+    int fit_reps = 10;
+    app.add_option("--fit-reps", fit_reps,
+                   "Number of repetitions in each sample (fit)");
+
+    int transform_samples = 1;
+    app.add_option("--transform-samples", transform_samples,
+                   "Number of samples to report (transform)");
+
+    int transform_reps = 10;
+    app.add_option("--transform-reps", transform_samples,
+                   "Number of repetitions in each sample (transform)");
+
+    int n_components = -1;
+    app.add_option("--n-components", n_components,
+                   "Number of components to get from PCA");
+
+    CLI11_PARSE(app, argc, argv);
+
+    std::vector<int> size;
+    parse_size(stringSize, size);
+    check_dims(size, 2);
+    int daal_threads = set_threads(num_threads);
+
+    // Find n_components
+    if (n_components == -1) {
+        n_components = std::min(size[1], (2 + std::min(size[0], size[1])) / 3);
+    }
+
+    std::string header_string = "Batch,Arch,Prefix,Threads,Size,n_components,Function,Time";
+    std::ostringstream meta_info_stream;
+    meta_info_stream
+        << batch << ','
+        << arch << ','
+        << prefix << ','
+        << daal_threads << ','
+        << stringSize << ','
+        << n_components << ',';
+    std::string meta_info = meta_info_stream.str();
+
+    if (header)
+        std::cout << header_string << std::endl;
+
+    // Actual bench here
+    double *X = gen_random(size[0] * size[1]);
+    double *Xp = gen_random(size[0] * size[1]);
+
+    double time;
+    da::pca::ResultPtr pca_result;
+    dm::NumericTablePtr U, S, V;
+    for (int i = 0; i < fit_samples; i++) {
+
+        // PCA fit also *might* return U, S, V...
+        std::tuple<da::pca::ResultPtr, dm::NumericTablePtr,
+                   dm::NumericTablePtr, dm::NumericTablePtr> fit_results;
+
+        // Get time and PCA results, including U, S, V.
+        // N.B.: we use DAAL solver here
+        std::tie(time, fit_results)
+            = time_min<std::tuple<da::pca::ResultPtr, dm::NumericTablePtr,
+                       dm::NumericTablePtr, dm::NumericTablePtr>> ([=] {
+                    return pca_fit_test(X, size[0], size[1], 'd', n_components);
+                }, fit_reps);
+
+        // Extract PCA results and U, S, V from tuple.
+        std::tie(pca_result, U, S, V) = fit_results;
+        std::cout << meta_info << "PCA.fit," << time << std::endl;
+    }
+
+    da::pca::transform::ResultPtr transform_result;
+    for (int i = 0; i < transform_samples; i++) {
+        std::tie(time, transform_result)
+            = time_min<da::pca::transform::ResultPtr> ([=] {
+                    return pca_transform_test(pca_result, Xp, size[0], size[1], n_components);
+                }, transform_reps);
+        std::cout << meta_info << "PCA.transform," << time << std::endl;
+    }
+    return 0;
+
+}

--- a/native/pca_bench.cpp
+++ b/native/pca_bench.cpp
@@ -22,7 +22,7 @@ pca_fit_daal(double *X, size_t rows, size_t cols, size_t n_components) {
 
     // Find number of components to use in DAAL
     if (n_components < 1) {
-        n_components = std::min(n_components, rows);
+        n_components = std::min(cols, rows);
     }
 
     da::pca::Batch<double, da::pca::svdDense> pca_algorithm;

--- a/native/pca_bench.cpp
+++ b/native/pca_bench.cpp
@@ -222,8 +222,8 @@ pca_fit_full_daal(double *X, size_t rows, size_t cols, size_t n_components) {
 
     // Need to take subcomponents of the eigenvalues and eigenvectors here.
     dm::NumericTablePtr orig_eigvals = pca_result->get(da::pca::eigenvalues);
-    dm::NumericTablePtr eigvals = copy_submatrix<double>(orig_eigvals, 0, 0, 1, n_components);
-    dm::NumericTablePtr eigvecs = copy_submatrix<double>(V, 0, 0, n_components, cols);
+    dm::NumericTablePtr eigvals = copy_submatrix<double>(orig_eigvals, 0, 1, 0, n_components);
+    dm::NumericTablePtr eigvecs = copy_submatrix<double>(V, 0, n_components, 0, cols);
 
     pca_result->set(da::pca::eigenvalues, eigvals);
     pca_result->set(da::pca::eigenvectors, eigvecs);

--- a/sklearn/pca.py
+++ b/sklearn/pca.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2017-2019 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+
+from __future__ import print_function
+import numpy as np
+import timeit
+from numpy.random import rand
+import sklearn
+from sklearn.decomposition import PCA
+from args import getArguments, coreString
+import bench
+
+import argparse
+parser = argparse.ArgumentParser(description="sklearn PCA benchmark")
+parser.add_argument('--svd-solver', type=str, choices=['daal', 'full'],
+                    default='daal', help='SVD solver to use')
+parser.add_argument('--n-components', type=int, default=None,
+                    help='Number of components to find')
+parser.add_argument('--whiten', action='store_true', default=False,
+                    help='Perform whitening')
+args = getArguments(parser)
+REP = args.iteration if args.iteration != '?' else 10
+core_number, daal_version = bench.prepare_benchmark(args)
+
+
+def st_time(func):
+    def st_func(*args, **keyArgs):
+        times = []
+        for n in range(REP):
+            t1 = timeit.default_timer()
+            r = func(*args, **keyArgs)
+            t2 = timeit.default_timer()
+            times.append(t2-t1)
+        print(min(times))
+        return r
+    return st_func
+
+p = args.size[0]
+n = args.size[1]
+X = rand(p,n)
+Xp = rand(p,n)
+
+if args.n_components:
+    n_components = args.n_components
+else:
+    n_components = min((n, (2 + min((n, p))) // 3))
+
+pca = PCA(svd_solver=args.svd_solver, whiten=args.whiten,
+          n_components=args.n_components)
+
+@st_time
+def test_fit(X):
+    pca.fit(X)
+
+@st_time
+def test_transform(X):
+    pca.transform(X)
+
+print (','.join([args.batchID, args.arch, args.prefix, "PCA.fit", coreString(args.num_threads), "Double", "%sx%s" % (p,n)]), end=',')
+test_fit(X)
+print (','.join([args.batchID, args.arch, args.prefix, "PCA.transform", coreString(args.num_threads), "Double", "%sx%s" % (p,n)]), end=',')
+test_transform(Xp)


### PR DESCRIPTION
This PR adds PCA benchmarks and NPY output for PCA.

Benchmarks support `svd_solver`s `daal` and `full`. They were verified against scikit-learn PCA using the NPY serialization.