### PR TITLE
Implement "target time" for benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,7 @@ ARGS_NATIVE_pca_full = 	--num-threads "$(NUM_THREADS)" --header \
 ARGS_NATIVE_kmeans = 	--num-threads "$(NUM_THREADS)" --header \
 			--data-multiplier "$(MULTIPLIER)" \
 			--filex data/kmeans_$(KMEANS_SIZE).npy \
-			--filei data/kmeans_$(KMEANS_SIZE).init.npy \
-			--filet data/kmeans_$(KMEANS_SIZE).tol.npy 
+			--filei data/kmeans_$(KMEANS_SIZE).init.npy
 ARGS_NATIVE_svm2 =	--fileX data/two/X-$(SVM_SIZE).npy \
 			--fileY data/two/y-$(SVM_SIZE).npy \
 			--num-threads $(SVM_NUM_THREADS) --header
@@ -159,8 +158,7 @@ ARGS_DAAL4PY_pca_daal = --size "$(REGRESSION_SIZE)" --svd-solver daal
 ARGS_DAAL4PY_pca_full = --size "$(REGRESSION_SIZE)" --svd-solver full
 ARGS_DAAL4PY_kmeans = 	--data-multiplier "$(MULTIPLIER)" \
 			--filex data/kmeans_$(KMEANS_SIZE).npy \
-			--filei data/kmeans_$(KMEANS_SIZE).init.npy \
-			--filet data/kmeans_$(KMEANS_SIZE).tol.npy
+			--filei data/kmeans_$(KMEANS_SIZE).init.npy
 ARGS_DAAL4PY_svm2 =	--fileX data/two/X-$(SVM_SIZE).npy \
 			--fileY data/two/y-$(SVM_SIZE).npy
 ARGS_DAAL4PY_svm5 = 	--fileX data/multi/X-$(SVM_SIZE).npy \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ DATA_DIR = data/
 DATA_kmeans = data/kmeans_$(KMEANS_SIZE).npy
 
 COMMON_ARGS =	--batch '$(BATCH)' --arch '$(HOST)' \
-		--num-threads '$(NUM_THREADS)' --header -v
+		--num-threads '$(NUM_THREADS)' --header
 
 # Define which benchmarks to run
 NATIVE_BENCHMARKS =	distances ridge linear kmeans svm2 svm5 \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ DATA_DIR = data/
 DATA_kmeans = data/kmeans_$(KMEANS_SIZE).npy
 
 COMMON_ARGS =	--batch '$(BATCH)' --arch '$(HOST)' \
-		--num-threads '$(NUM_THREADS)' --header
+		--num-threads '$(NUM_THREADS)' --header -v
 
 # Define which benchmarks to run
 NATIVE_BENCHMARKS =	distances ridge linear kmeans svm2 svm5 \

--- a/daal4py/bench.py
+++ b/daal4py/bench.py
@@ -245,8 +245,8 @@ def time_mean_min(func, *args, inner_loops=1, outer_loops=1, time_limit=10.,
             val = func(*args, **kwargs)
             t1 = timeit.default_timer()
 
-            warmup_time += t1 - t0
             last_warmup = t1 - t0
+            warmup_time += last_warmup
             if warmup_time > time_limit / 10:
                 break
 

--- a/daal4py/df_clsf.py
+++ b/daal4py/df_clsf.py
@@ -103,16 +103,20 @@ if __name__ == '__main__':
                                   seed=params.seed,
                                   n_features_per_node=params.max_features,
                                   max_depth=params.max_depth,
-                                  verbose=params.verbose,
                                   outer_loops=params.fit_outer_loops,
-                                  inner_loops=params.fit_inner_loops)
+                                  inner_loops=params.fit_inner_loops,
+                                  goal_outer_loops=params.fit_goal,
+                                  time_limit=params.fit_time_limit,
+                                  verbose=params.verbose)
     print_row(columns, params, function='df_clsf.fit', time=fit_time)
 
     predict_time, yp = time_mean_min(df_clsf_predict, X, res,
                                      params.n_classes,
-                                     verbose=params.verbose,
                                      outer_loops=params.predict_outer_loops,
-                                     inner_loops=params.predict_inner_loops)
+                                     inner_loops=params.predict_inner_loops,
+                                     goal_outer_loops=params.predict_goal,
+                                     time_limit=params.predict_time_limit,
+                                     verbose=params.verbose)
     acc = 100 * accuracy_score(yp, y)
     print_row(columns, params, function='df_clsf.predict', time=predict_time,
               accuracy=acc)

--- a/daal4py/df_regr.py
+++ b/daal4py/df_regr.py
@@ -99,10 +99,16 @@ if __name__ == '__main__':
                                   n_features_per_node=params.max_features,
                                   max_depth=params.max_depth,
                                   outer_loops=params.fit_outer_loops,
-                                  inner_loops=params.fit_inner_loops)
+                                  inner_loops=params.fit_inner_loops,
+                                  goal_outer_loops=params.fit_goal,
+                                  time_limit=params.fit_time_limit,
+                                  verbose=params.verbose)
     print_row(columns, params, function='df_regr.fit', time=fit_time)
 
     predict_time, yp = time_mean_min(df_regr_predict, X, res,
                                      outer_loops=params.predict_outer_loops,
-                                     inner_loops=params.predict_inner_loops)
+                                     inner_loops=params.predict_inner_loops,
+                                     goal_outer_loops=params.predict_goal,
+                                     time_limit=params.predict_time_limit,
+                                     verbose=params.verbose)
     print_row(columns, params, function='df_regr.predict', time=predict_time)

--- a/daal4py/distances.py
+++ b/daal4py/distances.py
@@ -32,5 +32,8 @@ for metric in params.metrics:
 
     time, _ = time_mean_min(test_distances, pairwise_distances, X,
                             outer_loops=params.outer_loops,
-                            inner_loops=params.inner_loops)
+                            inner_loops=params.inner_loops,
+                            goal_outer_loops=params.goal,
+                            time_limit=params.time_limit,
+                            verbose=params.verbose)
     print_row(columns, params, function=metric.capitalize(), time=time)

--- a/daal4py/kmeans.py
+++ b/daal4py/kmeans.py
@@ -14,8 +14,8 @@ parser.add_argument('-x', '--filex', '--fileX', '--input', required=True,
                     type=str, help='Points to cluster')
 parser.add_argument('-i', '--filei', '--fileI', '--init', required=True,
                     type=str, help='Initial clusters')
-parser.add_argument('-t', '--filet', '--fileT', '--tol', required=True,
-                    type=str, help='Absolute threshold')
+parser.add_argument('-t', '--tol', default=0., type=float,
+                    help='Absolute threshold')
 parser.add_argument('-m', '--data-multiplier', default=100,
                     type=int, help='Data multiplier')
 parser.add_argument('--maxiter', type=int, default=100,
@@ -26,7 +26,6 @@ params = parse_args(parser, loop_types=('fit', 'predict'), prefix='daal4py')
 X = np.load(params.filex)
 X_init = np.load(params.filei)
 X_mult = np.vstack((X,) * params.data_multiplier)
-tol = np.load(params.filet)
 
 params.size = size_str(X.shape)
 params.n_clusters = X_init.shape[0]
@@ -40,7 +39,7 @@ def test_fit(X, X_init):
         nClusters=params.n_clusters,
         maxIterations=params.maxiter,
         assignFlag=True,
-        accuracyThreshold=tol
+        accuracyThreshold=params.tol
     )
     return algorithm.compute(X, X_init)
 

--- a/daal4py/kmeans.py
+++ b/daal4py/kmeans.py
@@ -63,11 +63,17 @@ print_header(columns, params)
 # Time fit
 fit_time, _ = time_mean_min(test_fit, X, X_init,
                             outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops)
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
 print_row(columns, params, function='KMeans.fit', time=fit_time)
 
 # Time predict
 predict_time, _ = time_mean_min(test_predict, X, X_init,
                                 outer_loops=params.predict_outer_loops,
-                                inner_loops=params.predict_inner_loops)
+                                inner_loops=params.predict_inner_loops,
+                                goal_outer_loops=params.predict_goal,
+                                time_limit=params.predict_time_limit,
+                                verbose=params.verbose)
 print_row(columns, params, function='KMeans.predict', time=predict_time)

--- a/daal4py/linear.py
+++ b/daal4py/linear.py
@@ -48,6 +48,7 @@ print_header(columns, params)
 fit_time, res = time_mean_min(test_fit, X, y,
                               outer_loops=params.fit_outer_loops,
                               inner_loops=params.fit_inner_loops,
+                              goal_outer_loops=params.fit_goal,
                               time_limit=params.fit_time_limit,
                               verbose=params.verbose)
 print_row(columns, params, function='Linear.fit', time=fit_time)
@@ -56,6 +57,7 @@ print_row(columns, params, function='Linear.fit', time=fit_time)
 predict_time, yp = time_mean_min(test_predict, Xp, res.model,
                                  outer_loops=params.predict_outer_loops,
                                  inner_loops=params.predict_inner_loops,
+                                 goal_outer_loops=params.predict_goal,
                                  time_limit=params.predict_time_limit,
                                  verbose=params.verbose)
 print_row(columns, params, function='Linear.predict', time=predict_time)

--- a/daal4py/linear.py
+++ b/daal4py/linear.py
@@ -47,11 +47,15 @@ print_header(columns, params)
 # Time fit
 fit_time, res = time_mean_min(test_fit, X, y,
                               outer_loops=params.fit_outer_loops,
-                              inner_loops=params.fit_inner_loops)
+                              inner_loops=params.fit_inner_loops,
+                              time_limit=params.fit_time_limit,
+                              verbose=params.verbose)
 print_row(columns, params, function='Linear.fit', time=fit_time)
 
 # Time predict
 predict_time, yp = time_mean_min(test_predict, Xp, res.model,
                                  outer_loops=params.predict_outer_loops,
-                                 inner_loops=params.predict_inner_loops)
+                                 inner_loops=params.predict_inner_loops,
+                                 time_limit=params.predict_time_limit,
+                                 verbose=params.verbose)
 print_row(columns, params, function='Linear.predict', time=predict_time)

--- a/daal4py/log_reg.py
+++ b/daal4py/log_reg.py
@@ -222,13 +222,15 @@ if __name__ == '__main__':
 
     # Time fit and predict
     fit_time, res = time_mean_min(test_fit, X, y, penalty='l2', C=params.C,
-                                  verbose=params.verbose,
                                   fit_intercept=params.fit_intercept,
                                   tol=params.tol,
                                   max_iter=params.maxiter,
                                   solver=params.solver,
                                   outer_loops=params.fit_outer_loops,
-                                  inner_loops=params.fit_inner_loops)
+                                  inner_loops=params.fit_inner_loops,
+                                  goal_outer_loops=params.fit_goal,
+                                  time_limit=params.fit_time_limit,
+                                  verbose=params.verbose)
 
     beta, intercept, solver_result, params.multiclass = res
     print_row(columns, params, function='LogReg.fit', time=fit_time)
@@ -237,7 +239,10 @@ if __name__ == '__main__':
                                      intercept=intercept,
                                      multi_class=params.multiclass,
                                      outer_loops=params.predict_outer_loops,
-                                     inner_loops=params.predict_inner_loops)
+                                     inner_loops=params.predict_inner_loops,
+                                     goal_outer_loops=params.predict_goal,
+                                     time_limit=params.predict_time_limit,
+                                     verbose=params.verbose)
     y_pred = np.argmax(yp, axis=1)
     acc = 100 * accuracy_score(y_pred, y)
     print_row(columns, params, function='LogReg.predict', time=predict_time,

--- a/daal4py/pca.py
+++ b/daal4py/pca.py
@@ -123,13 +123,19 @@ print_header(columns, params)
 # Time fit
 fit_time, res = time_mean_min(test_fit, X,
                               outer_loops=params.fit_outer_loops,
-                              inner_loops=params.fit_inner_loops)
+                              inner_loops=params.fit_inner_loops,
+                              goal_outer_loops=params.fit_goal,
+                              time_limit=params.fit_time_limit,
+                              verbose=params.verbose)
 print_row(columns, params, function='PCA.fit', time=fit_time)
 
 # Time transform
 transform_time, tr = time_mean_min(test_transform, Xp, *res[:3],
                                    outer_loops=params.transform_outer_loops,
-                                   inner_loops=params.transform_inner_loops)
+                                   inner_loops=params.transform_inner_loops,
+                                   goal_outer_loops=params.predict_goal,
+                                   time_limit=params.predict_time_limit,
+                                   verbose=params.verbose)
 print_row(columns, params, function='PCA.transform', time=transform_time)
 
 if params.write_results:

--- a/daal4py/pca.py
+++ b/daal4py/pca.py
@@ -133,8 +133,8 @@ print_row(columns, params, function='PCA.fit', time=fit_time)
 transform_time, tr = time_mean_min(test_transform, Xp, *res[:3],
                                    outer_loops=params.transform_outer_loops,
                                    inner_loops=params.transform_inner_loops,
-                                   goal_outer_loops=params.predict_goal,
-                                   time_limit=params.predict_time_limit,
+                                   goal_outer_loops=params.transform_goal,
+                                   time_limit=params.transform_time_limit,
                                    verbose=params.verbose)
 print_row(columns, params, function='PCA.transform', time=transform_time)
 

--- a/daal4py/ridge.py
+++ b/daal4py/ridge.py
@@ -41,11 +41,17 @@ print_header(columns, params)
 # Time fit
 fit_time, res = time_mean_min(test_fit, X, y,
                               outer_loops=params.fit_outer_loops,
-                              inner_loops=params.fit_inner_loops)
+                              inner_loops=params.fit_inner_loops,
+                              goal_outer_loops=params.fit_goal,
+                              time_limit=params.fit_time_limit,
+                              verbose=params.verbose)
 print_row(columns, params, function='Ridge.fit', time=fit_time)
 
 # Time predict
 predict_time, yp = time_mean_min(test_predict, Xp, res.model,
                                  outer_loops=params.predict_outer_loops,
-                                 inner_loops=params.predict_inner_loops)
+                                 inner_loops=params.predict_inner_loops,
+                                 goal_outer_loops=params.predict_goal,
+                                 time_limit=params.predict_time_limit,
+                                 verbose=params.verbose)
 print_row(columns, params, function='Ridge.predict', time=predict_time)

--- a/daal4py/svm.py
+++ b/daal4py/svm.py
@@ -344,14 +344,20 @@ def main():
     # Time fit and predict
     fit_time, res = time_mean_min(test_fit, X_train, y_train, params,
                                   outer_loops=params.fit_outer_loops,
-                                  inner_loops=params.fit_inner_loops)
+                                  inner_loops=params.fit_inner_loops,
+                                  goal_outer_loops=params.fit_goal,
+                                  time_limit=params.fit_time_limit,
+                                  verbose=params.verbose)
     res, support, indices, n_support = res
     params.sv_len = support.shape[0]
     print_row(columns, params, function='SVM.fit', time=fit_time)
 
     predict_time, yp = time_mean_min(test_predict, X_train, res, params,
                                      outer_loops=params.predict_outer_loops,
-                                     inner_loops=params.predict_inner_loops)
+                                     inner_loops=params.predict_inner_loops,
+                                     goal_outer_loops=params.predict_goal,
+                                     time_limit=params.predict_time_limit,
+                                     verbose=params.verbose)
     print_row(columns, params, function='SVM.predict', time=predict_time,
               accuracy=f'{100*accuracy_score(yp, y_train):.3}')
 

--- a/native/common.hpp
+++ b/native/common.hpp
@@ -417,7 +417,7 @@ void add_common_args(CLI::App &app,
     app.add_flag("--header", header, "Output CSV header");
 
     verbose = false;
-    app.add_flag("--verbose", verbose, "Output extra debug messages");
+    app.add_flag("-v,--verbose", verbose, "Output extra debug messages");
 
 }
 

--- a/native/common.hpp
+++ b/native/common.hpp
@@ -396,6 +396,37 @@ double *gen_random(size_t n) {
 }
 
 
+/*
+ * Print the given numeric table (for diagnostic purposes)
+ */
+void print_numeric_table(dm::NumericTablePtr X_nt, std::string label) {
+
+    size_t n_cols = X_nt->getNumberOfColumns();
+    size_t n_rows = X_nt->getNumberOfRows();
+
+    dm::BlockDescriptor<double> blockX;
+    X_nt->getBlockOfRows(0, n_rows, dm::readOnly, blockX);
+
+    std::streamsize prec = std::cout.precision();
+
+    double *x = blockX.getBlockPtr();
+    std::cout << "@ " << label << " (" << n_rows << 'x' << n_cols
+        << "):" << std::endl;
+    std::cout << std::setprecision(18) << std::scientific;
+    for (size_t i = 0; i < n_rows; i++) {
+        std::cout << "@ ";
+        for (size_t j = 0; j < n_cols; j++) {
+            std::cout << x[j + i * n_cols] << ", ";
+        }
+        std::cout << std::endl;
+    }
+	std::cout << std::setprecision(prec) << std::defaultfloat;
+
+    X_nt->releaseBlockOfRows(blockX);
+
+}
+
+
 void add_common_args(CLI::App &app,
                      std::string &batch, std::string &arch,
                      std::string &prefix, int &num_threads,

--- a/native/decision_forest_clsf_bench.cpp
+++ b/native/decision_forest_clsf_bench.cpp
@@ -16,6 +16,7 @@
 #include "daal.h"
 #include "CLI11.hpp"
 #include "npyfile.h"
+#include "common.hpp"
 
 namespace dm=daal::data_management;
 namespace ds=daal::services;
@@ -25,8 +26,6 @@ namespace dfc=daal::algorithms::decision_forest::classification;
 
 using namespace daal;
 using namespace da;
-
-void print_numeric_table(dm::NumericTablePtr, std::string);
 
 
 dfc::training::ResultPtr
@@ -102,110 +101,73 @@ df_classification_predict(
     return Y_pred_t;
 }
 
-size_t
-count_same_labels(
-    dm::NumericTablePtr Y_nt,
-    dm::NumericTablePtr Yp_nt,
-    size_t n_rows)
-{
-    size_t equal_counter = 0;
-    dm::BlockDescriptor<double> blockY;
-    dm::BlockDescriptor<double> blockYp;
-    Yp_nt->getBlockOfRows(0, n_rows, dm::readOnly, blockYp);
-    Y_nt->getBlockOfRows(0, n_rows, dm::readOnly, blockY);
-    double *Y_data_ptr = blockY.getBlockPtr();
-    double *Yp_data_ptr = blockYp.getBlockPtr();
 
-    for(size_t i = 0; i < n_rows; i++) {
-	equal_counter += (fabs(Y_data_ptr[i] - Yp_data_ptr[i]) < 0.5) ? 1 : 0;
-    }
-    Yp_nt->releaseBlockOfRows(blockYp);
-    Y_nt->releaseBlockOfRows(blockY);
+int main(int argc, char** argv) {
+    CLI::App app("Native benchmark code for Intel(R) DAAL random forest classifier");
 
-    return equal_counter;
-}
+    std::string batch, arch, prefix;
+    int num_threads;
+    bool header, verbose;
+    add_common_args(app, batch, arch, prefix, num_threads, header, verbose);
 
-int
-find_nClasses(dm::NumericTablePtr Y_nt)
-{
-    /* compute min and max labels with DAAL */
-    da::low_order_moments::Batch<double> algorithm;
-    algorithm.input.set(da::low_order_moments::data, Y_nt);
-    algorithm.compute();
-    da::low_order_moments::ResultPtr res = algorithm.getResult();
-    dm::NumericTablePtr min_nt = res->get(da::low_order_moments::minimum);
-    dm::NumericTablePtr max_nt = res->get(da::low_order_moments::maximum);
-    int min, max;
-    dm::BlockDescriptor<> block;
-    min_nt->getBlockOfRows(0, 1, dm::readOnly, block);
-    min = block.getBlockPtr()[0];
-    max_nt->getBlockOfRows(0, 1, dm::readOnly, block);
-    max = block.getBlockPtr()[0];
-    return 1 + max - min;
-}
+    std::string xfn = "./data/mX.csv";
+    app.add_option("-x,--fileX", xfn, "Feature file name")
+        ->required()
+        ->check(CLI::ExistingFile);
 
+    std::string yfn = "./data/mY.csv";
+    app.add_option("-y,--fileY", yfn, "Labels file name")
+        ->required()
+        ->check(CLI::ExistingFile);
 
-void
-print_numeric_table(dm::NumericTablePtr X_nt, std::string label)
-{
-    size_t n_cols = X_nt->getNumberOfColumns();
-    size_t n_rows = X_nt->getNumberOfRows();
+    struct timing_options fit_opts = {100, 100, 10., 10};
+    add_timing_args(app, "fit", fit_opts);
 
-    dm::BlockDescriptor<double> blockX;
-    X_nt->getBlockOfRows(0, n_rows, dm::readOnly, blockX);
+    struct timing_options predict_opts = {10, 100, 10., 10};
+    add_timing_args(app, "predict", predict_opts);
 
-    double *x = blockX.getBlockPtr();
-    std::cout << "@ " << label << ":" << std::endl;
-    std::cout << std::setprecision(18) << std::scientific;
-    for (size_t i_outer=0; i_outer < n_rows; i_outer++) {
-	std::cout << "@ ";
-	for(size_t i_inner=0; i_inner < n_cols; i_inner++) {
-	    std::cout << x[i_inner + i_outer * n_cols] << ", ";
-	}
-	std::cout << std::endl;
-    }
+    bool no_bootstrap = false;
+    app.add_flag("--no-bootstrap", no_bootstrap,
+                 "Do not use bootstrap samples to build trees");
 
-    X_nt->releaseBlockOfRows(blockX);
-}
+    size_t n_trees = 100;
+    app.add_option("--num-trees", n_trees,
+                   "Number of trees in decision forest", true);
 
-void
-bench(
-    size_t threadNum,
-    const std::string& X_fname,
-    const std::string& y_fname,
-    int fit_samples,
-    int fit_repetitions,
-    int predict_samples,
-    int predict_repetitions,
-    bool verbose,
-    bool header,
-    size_t n_trees, size_t seed, size_t n_features_per_node, size_t max_depth, double min_impurity, bool bootstrap)
-{
-    /* Set the maximum number of threads to be used by the library */
-    if (threadNum != 0)
-        daal::services::Environment::getInstance()->setNumberOfThreads(threadNum);
+    size_t n_features_per_node = 0;
+    app.add_option("--features-per-node", n_features_per_node,
+                   "Number of features per node", true);
 
-    size_t daal_thread_num = daal::services::Environment::getInstance()->getNumberOfThreads();
+    size_t max_depth = 0;
+    app.add_option("--max-depth", max_depth,
+                   "Maximal depth of trees in the forest. "
+                   "Zero means depth is not limited.", true);
+
+    size_t seed = 12345;
+    app.add_option("--seed", seed, "Number of features per node", true);
+
+    double min_impurity = 0.;
+
+    CLI11_PARSE(app, argc, argv);
+
+    bool bootstrap = !no_bootstrap;
 
     /* Load data */
-    struct npyarr *arrX = load_npy(X_fname.c_str());
-    struct npyarr *arrY = load_npy(y_fname.c_str());
+    struct npyarr *arrX = load_npy(xfn.c_str());
+    struct npyarr *arrY = load_npy(yfn.c_str());
     if (!arrX || !arrY) {
         std::cerr << "Failed to load input arrays" << std::endl;
-        std::exit(1);
-        return;
+        return EXIT_FAILURE;
     }
     if (arrX->shape_len != 2) {
         std::cerr << "Expected 2 dimensions for X, found "
             << arrX->shape_len << std::endl;
-        std::exit(1);
-        return;
+        return EXIT_FAILURE;
     }
     if (arrY->shape_len != 1) {
         std::cerr << "Expected 1 dimension for y, found "
             << arrY->shape_len << std::endl;
-        std::exit(1);
-        return;
+        return EXIT_FAILURE;
     }
 
     /* Create numeric tables */
@@ -214,121 +176,65 @@ bench(
     dm::NumericTablePtr Y_nt = dm::HomogenNumericTable<int64_t>::create(
             (int64_t *) arrY->data, 1, arrY->shape[0]);
 
-    int n_classes = find_nClasses(Y_nt);
-
-    std::vector<std::chrono::duration<double> > fit_times;
-    dfc::training::ResultPtr training_result;
-    for(int i = 0; i < fit_samples; i++) {
-        auto start = std::chrono::system_clock::now();
-	for(int j=0; j < fit_repetitions; j++) {
-	    training_result = df_classification_fit(
-		n_classes, n_trees, seed, n_features_per_node, max_depth, min_impurity, bootstrap,
-		X_nt, Y_nt, verbose && (!i) && (!j)
-		);
-	}
-        auto finish = std::chrono::system_clock::now();
-        fit_times.push_back(finish - start);
-    }
-
-    std::vector<std::chrono::duration<double> > predict_times;
-    dm::NumericTablePtr Yp_nt;
-    for(int i=0; i < predict_samples; i++) {
-        auto start = std::chrono::system_clock::now();
-        for(int j=0; j < predict_repetitions; j++) {
-	    Yp_nt = df_classification_predict(
-		n_classes, training_result,
-		X_nt, verbose && (!i) && (!j));
-	}
-        auto finish = std::chrono::system_clock::now();
-        predict_times.push_back(finish - start);
-
-    }
-
     size_t n_rows = Y_nt->getNumberOfRows();
-    size_t equal_counter = count_same_labels(Y_nt, Yp_nt, n_rows);
-    double accuracy = ((double) equal_counter / (double) n_rows) * 100.00;
+    size_t n_features = X_nt->getNumberOfColumns();
+    std::ostringstream string_size_stream;
+    string_size_stream << n_rows << 'x' << n_features;
+    std::string stringSize = string_size_stream.str();
+
+    // Set DAAL threads
+    int daal_threads = set_threads(num_threads);
+
+    int n_classes = count_classes(Y_nt);
+
+    // Prepare header and metadata info
+    std::string header_string = "batch,arch,prefix,threads,size,classes,"
+                                "n_trees,n_features_per_node,max_depth,"
+                                "min_impurity,bootstrap,function,accuracy,"
+                                "time";
+    std::ostringstream meta_info_stream;
+    meta_info_stream
+        << batch << ','
+        << arch << ','
+        << prefix << ','
+        << daal_threads << ','
+        << stringSize << ','
+        << n_classes << ','
+        << n_trees << ','
+        << n_features_per_node << ','
+        << max_depth << ','
+        << min_impurity << ','
+        << bootstrap << ',';
+    std::string meta_info = meta_info_stream.str();
+
+    // Actually time benchmarks
+
+    double time;
+    bool verbose_fit = verbose;
+    dfc::training::ResultPtr training_result;
+    std::tie(time, training_result) = time_min<dfc::training::ResultPtr> ([&] {
+            auto r = df_classification_fit(n_classes, n_trees, seed,
+                                           n_features_per_node, max_depth,
+                                           min_impurity, bootstrap, X_nt, Y_nt,
+                                           verbose_fit);
+            verbose_fit = false;
+            return r;
+        }, fit_opts, verbose);
 
     if (header) {
-	std::cout <<
-        ""  << "prefix_ID"     <<
-        "," << "function"      <<
-        "," << "threads"       <<
-        "," << "rows"          <<
-        "," << "features"      <<
-        "," << "fit"           <<
-        "," << "predict"       <<
-        "," << "accuracy"      <<
-        "," << "classes"       << std::endl;
+        std::cout << header_string << std::endl;
     }
+    std::cout << meta_info << "df_clsf.fit,," << time << std::endl;
 
-    std::cout << "Native-C,df_clsf," << daal_thread_num;
-    std::cout << "," << X_nt->getNumberOfRows() <<
-	         "," << X_nt->getNumberOfColumns();
-    std::cout << "," << std::min_element(fit_times.begin(), fit_times.end())->count() / fit_repetitions;
-    std::cout << "," << std::min_element(predict_times.begin(), predict_times.end())->count() / predict_repetitions;
-    std::cout << "," << accuracy;
-    std::cout << "," << n_classes; // number of classes
-    std::cout << std::endl;
-}
+    dm::NumericTablePtr Yp_nt;
+    std::tie(time, Yp_nt) = time_min<dm::NumericTablePtr> ([&] {
+            return df_classification_predict(n_classes, training_result,
+                                             X_nt, verbose);
+        }, predict_opts, verbose);
 
-int main(int argc, char** argv) {
-    CLI::App app("Native benchmark code for Intel(R) DAAL random forest classifier");
+    double accuracy = accuracy_score(Y_nt, Yp_nt) * 100.;
+    std::cout << meta_info << "df_clsf.predict," << accuracy << ','
+        << time << std::endl;
 
-    std::string xfn = "./data/mX.csv";
-    CLI::Option *optX = app.add_option("--fileX", xfn, "Feature file name")->required()->check(CLI::ExistingFile);
-
-    std::string yfn = "./data/mY.csv";
-    CLI::Option *optY = app.add_option("--fileY", yfn, "Labels file name")->required()->check(CLI::ExistingFile);
-
-    int fit_samples = 3, fit_repetitions = 1, predict_samples = 5, predict_repetitions = 50;
-    CLI::Option *optFitS = app.add_option("--fit-samples", fit_samples, "Number of samples to collect for time of execution of repeated fit calls", true);
-    CLI::Option *optFitR = app.add_option("--fit-repetitions", fit_repetitions, "Number of repeated fit calls to time", true);
-    CLI::Option *optPredS = app.add_option("--predict-samples", predict_samples, "Number of samples to collect for time of execution of repeated predict calls", true);
-    CLI::Option *optPredR = app.add_option("--predict-repetitions", predict_repetitions, "Number of repeated predict calls to time", true);
-
-    int num_threads = 0;
-    CLI::Option *optNumThreads = app.add_option("-n,--num-threads", num_threads, "Number of threads for DAAL to use", true);
-
-    bool verbose = false;
-    CLI::Option *optVerbose = app.add_flag("-v,--verbose", verbose, "Whether to be verbose or terse");
-
-    bool header = false;
-    CLI::Option *optHeader = app.add_flag("--header", header, "Whether to output header");
-
-    bool no_bootstrap = false;
-    CLI::Option *optNoBootstrap = app.add_flag("--no-bootstrap", no_bootstrap, "Whether to output header");
-
-    size_t num_trees = 100;
-    CLI::Option *optNumTrees = app.add_option("--num-trees", num_trees, "Number of trees in decision forest", true);
-
-    size_t num_features_per_node = 0;
-    CLI::Option *optFeaturesPerNode = app.add_option("--features-per-node", num_features_per_node, "Number of features per node", true);
-
-    size_t max_depth = 0;
-    CLI::Option *optMaxDepth = app.add_option("--max-depth", max_depth, "Maximal depth of trees in the forest. Zero means depth is not limited.", true);
-
-    size_t seed = 12345;
-    CLI::Option *optSeed = app.add_option("--seed", seed, "Number of features per node", true);
-
-    CLI11_PARSE(app, argc, argv);
-
-    assert(num_threads >= 0);
-    assert(fit_samples > 0);
-    assert(fit_repetitions > 0);
-    assert(predict_samples > 0);
-    assert(predict_repetitions > 0);
-
-    if (verbose) {
-	std::clog <<
-	    "@ {FIT_SAMPLES: "        << fit_samples <<
-	    ", FIT_REPETIONS: "       << fit_repetitions <<
-	    ", PREDICT_SAMPLES: "     << predict_samples <<
-	    ", PREDICT_REPETITIONS: " << predict_repetitions <<
-	    "}" << std::endl;
-    }
-
-    bench(num_threads, xfn, yfn, fit_samples, fit_repetitions, predict_samples, predict_repetitions, verbose, header,
-	  num_trees, seed, num_features_per_node, max_depth, 0., !no_bootstrap);
-
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/native/decision_forest_regr_bench.cpp
+++ b/native/decision_forest_regr_bench.cpp
@@ -16,6 +16,7 @@
 #include "daal.h"
 #include "CLI11.hpp"
 #include "npyfile.h"
+#include "common.hpp"
 
 namespace dm=daal::data_management;
 namespace ds=daal::services;
@@ -25,8 +26,6 @@ namespace dfr=daal::algorithms::decision_forest::regression;
 
 using namespace daal;
 using namespace da;
-
-void print_numeric_table(dm::NumericTablePtr, std::string);
 
 dfr::training::ResultPtr
 df_regression_fit(
@@ -137,73 +136,73 @@ explained_variance_score(
 }
 
 
-void
-print_numeric_table(dm::NumericTablePtr X_nt, std::string label)
-{
-    size_t n_cols = X_nt->getNumberOfColumns();
-    size_t n_rows = X_nt->getNumberOfRows();
+int main(int argc, char** argv) {
+    CLI::App app("Native benchmark code for Intel(R) DAAL "
+                 "random forest regressor");
 
-    dm::BlockDescriptor<double> blockX;
-    X_nt->getBlockOfRows(0, n_rows, dm::readOnly, blockX);
+    std::string batch, arch, prefix;
+    int num_threads;
+    bool header, verbose;
+    add_common_args(app, batch, arch, prefix, num_threads, header, verbose);
 
-    double *x = blockX.getBlockPtr();
-    std::cout << "@ " << label << ":" << std::endl;
-    std::cout << std::setprecision(18) << std::scientific;
-    for (size_t i_outer=0; i_outer < n_rows; i_outer++) {
-    std::cout << "@ ";
-    for(size_t i_inner=0; i_inner < n_cols; i_inner++) {
-        std::cout << x[i_inner + i_outer * n_cols] << ", ";
-    }
-    std::cout << std::endl;
-    }
+    std::string xfn = "./data/mX.csv";
+    app.add_option("-x,--fileX", xfn, "Feature file name")
+        ->required()
+        ->check(CLI::ExistingFile);
 
-    X_nt->releaseBlockOfRows(blockX);
-}
+    std::string yfn = "./data/mY.csv";
+    app.add_option("-y,--fileY", yfn, "Labels file name")
+        ->required()
+        ->check(CLI::ExistingFile);
 
+    struct timing_options fit_opts = {100, 100, 10., 10};
+    add_timing_args(app, "fit", fit_opts);
 
-void
-bench(
-    size_t threadNum,
-    const std::string& X_fname,
-    const std::string& y_fname,
-    int fit_samples,
-    int fit_repetitions,
-    int predict_samples,
-    int predict_repetitions,
-    bool verbose,
-    bool header,
-    size_t n_trees,
-    size_t seed,
-    size_t n_features_per_node,
-    size_t max_depth,
-    double min_impurity,
-    bool bootstrap)
-{
-    /* Set the maximum number of threads to be used by the library */
-    if (threadNum != 0)
-        ds::Environment::getInstance()->setNumberOfThreads(threadNum);
+    struct timing_options predict_opts = {10, 100, 10., 10};
+    add_timing_args(app, "predict", predict_opts);
 
-    threadNum = ds::Environment::getInstance()->getNumberOfThreads();
+    bool no_bootstrap = false;
+    app.add_flag("--no-bootstrap", no_bootstrap,
+                 "Do not use bootstrap samples to build trees");
+
+    size_t n_trees = 100;
+    app.add_option("--num-trees", n_trees,
+                   "Number of trees in decision forest", true);
+
+    size_t n_features_per_node = 0;
+    app.add_option("--features-per-node", n_features_per_node,
+                   "Number of features per node", true);
+
+    size_t max_depth = 0;
+    app.add_option("--max-depth", max_depth,
+                   "Maximal depth of trees in the forest. "
+                   "Zero means depth is not limited.", true);
+
+    size_t seed = 12345;
+    app.add_option("--seed", seed, "Seed for the MT2203 RNG", true);
+
+    double min_impurity = 0.;
+
+    CLI11_PARSE(app, argc, argv);
+
+    bool bootstrap = !no_bootstrap;
 
     /* Load data */
-    struct npyarr *arrX = load_npy(X_fname.c_str());
-    struct npyarr *arrY = load_npy(y_fname.c_str());
+    struct npyarr *arrX = load_npy(xfn.c_str());
+    struct npyarr *arrY = load_npy(yfn.c_str());
     if (!arrX || !arrY) {
         std::cerr << "Failed to load input arrays" << std::endl;
-        std::exit(1);
-        return;
+        return EXIT_FAILURE;
     }
     if (arrX->shape_len != 2) {
         std::cerr << "Expected 2 dimensions for X, found "
             << arrX->shape_len << std::endl;
-        std::exit(1);
-        return;
+        return EXIT_FAILURE;
     }
     if (arrY->shape_len != 1) {
         std::cerr << "Expected 1 dimension for y, found "
             << arrY->shape_len << std::endl;
-        std::exit(1);
-        return;
+        return EXIT_FAILURE;
     }
 
     /* Create numeric tables */
@@ -212,136 +211,60 @@ bench(
     dm::NumericTablePtr Y_nt = dm::HomogenNumericTable<double>::create(
             (double *) arrY->data, 1, arrY->shape[0]);
 
-    std::vector<std::chrono::duration<double> > fit_times;
-    dfr::training::ResultPtr training_result;
-    for(int i = 0; i < fit_samples; i++) {
-        auto start = std::chrono::system_clock::now();
-    for(int j=0; j < fit_repetitions; j++) {
-        training_result = df_regression_fit(
-        n_trees, seed, n_features_per_node, max_depth, min_impurity, bootstrap,
-        X_nt, Y_nt, verbose && (!i) && (!j)
-        );
-    }
-        auto finish = std::chrono::system_clock::now();
-        fit_times.push_back(finish - start);
-    }
-
-    std::vector<std::chrono::duration<double> > predict_times;
-    dm::NumericTablePtr Yp_nt;
-    for(int i=0; i < predict_samples; i++) {
-        auto start = std::chrono::system_clock::now();
-        for(int j=0; j < predict_repetitions; j++) {
-        Yp_nt = df_regression_predict(
-        training_result,
-        X_nt, verbose && (!i) && (!j));
-    }
-        auto finish = std::chrono::system_clock::now();
-        predict_times.push_back(finish - start);
-
-    }
-
     size_t n_rows = Y_nt->getNumberOfRows();
-    double accuracy = explained_variance_score(Y_nt, Yp_nt, n_rows);
+    size_t n_features = X_nt->getNumberOfColumns();
+    std::ostringstream string_size_stream;
+    string_size_stream << n_rows << 'x' << n_features;
+    std::string stringSize = string_size_stream.str();
+
+    // Set DAAL threads
+    int daal_threads = set_threads(num_threads);
+
+    // Prepare header and metadata info
+    std::string header_string = "batch,arch,prefix,threads,size,"
+                                "n_trees,n_features_per_node,max_depth,"
+                                "min_impurity,bootstrap,function,accuracy,"
+                                "time";
+    std::ostringstream meta_info_stream;
+    meta_info_stream
+        << batch << ','
+        << arch << ','
+        << prefix << ','
+        << daal_threads << ','
+        << stringSize << ','
+        << n_trees << ','
+        << n_features_per_node << ','
+        << max_depth << ','
+        << min_impurity << ','
+        << bootstrap << ',';
+    std::string meta_info = meta_info_stream.str();
+
+    // Actually time benchmarks
+    
+    double time;
+    bool verbose_fit = verbose;
+    dfr::training::ResultPtr training_result;
+    std::tie(time, training_result) = time_min<dfr::training::ResultPtr> ([&] {
+            auto r = df_regression_fit(n_trees, seed, n_features_per_node,
+                                       max_depth, min_impurity, bootstrap,
+                                       X_nt, Y_nt, verbose_fit);
+            verbose_fit = false;
+            return r;
+        }, fit_opts, verbose);
 
     if (header) {
-    std::cout <<
-        ""  << "prefix_ID"     <<
-        "," << "function"      <<
-        "," << "threads"       <<
-        "," << "rows"          <<
-        "," << "features"      <<
-        "," << "fit"           <<
-        "," << "predict"       <<
-        "," << "accuracy"      << std::endl;
+        std::cout << header_string << std::endl;
     }
+    std::cout << meta_info << "df_regr.fit,," << time << std::endl;
 
-    std::cout << "Native-C,df_regr," << threadNum;
-    std::cout << "," << X_nt->getNumberOfRows()
-              << "," << X_nt->getNumberOfColumns();
-    std::cout << "," << std::min_element(fit_times.begin(),
-            fit_times.end())->count() / fit_repetitions;
-    std::cout << "," << std::min_element(predict_times.begin(),
-            predict_times.end())->count() / predict_repetitions;
-    std::cout << "," << (100 * accuracy);
-    std::cout << std::endl;
-}
+    dm::NumericTablePtr Yp_nt;
+    std::tie(time, Yp_nt) = time_min<dm::NumericTablePtr> ([&] {
+            return df_regression_predict(training_result, X_nt, verbose);
+        }, predict_opts, verbose);
 
-int main(int argc, char** argv) {
-    CLI::App app("Native benchmark code for Intel(R) DAAL "
-                 "random forest regressor");
+    double accuracy = explained_variance_score(Y_nt, Yp_nt, n_rows);
+    std::cout << meta_info << "df_regr.predict," << accuracy << ','
+        << time << std::endl;
 
-    std::string xfn = "./data/mX.csv";
-    app.add_option("--fileX", xfn, "Feature file name")
-        ->required()->check(CLI::ExistingFile);
-
-    std::string yfn = "./data/mY.csv";
-    app.add_option("--fileY", yfn, "Labels file name")
-        ->required()->check(CLI::ExistingFile);
-
-    int fit_samples = 3, fit_repetitions = 1,
-        predict_samples = 5, predict_repetitions = 50;
-    app.add_option("--fit-samples", fit_samples,
-                   "Number of samples to collect for time of execution of "
-                   "repeated fit calls", true);
-    app.add_option("--fit-repetitions", fit_repetitions,
-                   "Number of repeated fit calls to time", true);
-    app.add_option("--predict-samples", predict_samples,
-                   "Number of samples to collect for time of execution of "
-                   "repeated predict calls", true);
-    app.add_option("--predict-repetitions", predict_repetitions,
-                   "Number of repeated predict calls to time", true);
-
-    int num_threads = 0;
-    app.add_option("-n,--num-threads", num_threads,
-                   "Number of threads for DAAL to use", true);
-
-    bool verbose = false;
-    app.add_flag("-v,--verbose", verbose, "Whether to be verbose or terse");
-
-    bool header = false;
-    app.add_flag("--header", header, "Whether to output header");
-
-    bool no_bootstrap = false;
-    app.add_flag("--no-bootstrap", no_bootstrap,
-                 "Do not use bootstrap samples to build trees");
-
-    size_t num_trees = 100;
-    app.add_option("--num-trees", num_trees,
-                   "Number of trees in decision forest", true);
-
-    size_t max_depth = 0;
-    app.add_option("--max-depth", max_depth,
-                   "Maximal depth of trees in the forest. "
-                   "Zero means depth is not limited.", true);
-
-    size_t num_features_per_node = 0;
-    app.add_option("--features-per-node", num_features_per_node,
-                   "Number of features per node", true);
-
-    size_t seed = 12345;
-    app.add_option("--seed", seed, "Seed for the MT2203 RNG", true);
-
-
-    CLI11_PARSE(app, argc, argv);
-
-    assert(num_threads >= 0);
-    assert(fit_samples > 0);
-    assert(fit_repetitions > 0);
-    assert(predict_samples > 0);
-    assert(predict_repetitions > 0);
-
-    if (verbose) {
-    std::clog <<
-        "@ {FIT_SAMPLES: "        << fit_samples <<
-        ", FIT_REPETITIONS: "     << fit_repetitions <<
-        ", PREDICT_SAMPLES: "     << predict_samples <<
-        ", PREDICT_REPETITIONS: " << predict_repetitions <<
-        "}" << std::endl;
-    }
-
-    bench(num_threads, xfn, yfn, fit_samples, fit_repetitions, predict_samples,
-          predict_repetitions, verbose, header, num_trees, seed,
-          num_features_per_node, max_depth, 0., !no_bootstrap);
-
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/native/distances_bench.cpp
+++ b/native/distances_bench.cpp
@@ -45,12 +45,8 @@ int main(int argc, char *argv[]) {
     std::string stringSize = "1000x150000";
     app.add_option("-s,--size", stringSize, "Problem size");
 
-    int samples = 1;
-    app.add_option("--samples", samples, "Number of samples to report");
-
-    int reps = 10;
-    app.add_option("-r,--reps", samples, "Number of repetitions in each sample");
-
+    struct timing_options timing_opts = {100, 100, 10., 10};
+    add_timing_args(app, "", timing_opts);
 
     CLI11_PARSE(app, argc, argv);
 
@@ -77,17 +73,15 @@ int main(int argc, char *argv[]) {
     double time;
     dm::NumericTablePtr result;
 
-    for (int i = 0; i < samples; i++) {
-        std::tie(time, result) = time_min<dm::NumericTablePtr> ([=] {
-                    return correlation_test(X, size[0], size[1]);
-                }, reps);
-        std::cout << meta_info << "Correlation," << time << std::endl;
+    std::tie(time, result) = time_min<dm::NumericTablePtr> ([=] {
+                return correlation_test(X, size[0], size[1]);
+            }, timing_opts, verbose);
+    std::cout << meta_info << "Correlation," << time << std::endl;
 
-        std::tie(time, result) = time_min<dm::NumericTablePtr> ([=] {
-                    return cosine_test(X, size[0], size[1]);
-                }, reps);
-        std::cout << meta_info << "Cosine," << time << std::endl;
-    }
+    std::tie(time, result) = time_min<dm::NumericTablePtr> ([=] {
+                return cosine_test(X, size[0], size[1]);
+            }, timing_opts, verbose);
+    std::cout << meta_info << "Cosine," << time << std::endl;
     return 0;
 
 }

--- a/native/kmeans_bench.cpp
+++ b/native/kmeans_bench.cpp
@@ -102,8 +102,7 @@ int main(int argc, char *argv[]) {
         ->required()->check(CLI::ExistingFile);
 
     double tol = 0.;
-    app.add_option("-t,--tol", tol, "Absolute threshold")
-        ->required()->check(CLI::ExistingFile);
+    app.add_option("-t,--tol", tol, "Absolute threshold");
 
     int data_multiplier = 100;
     app.add_option("-m,--data-multiplier", data_multiplier, "Data multiplier");

--- a/native/kmeans_bench.cpp
+++ b/native/kmeans_bench.cpp
@@ -93,15 +93,16 @@ int main(int argc, char *argv[]) {
     struct timing_options predict_opts = {10, 100, 10., 10};
     add_timing_args(app, "predict", predict_opts);
 
-    std::string filex, filei, filet;
+    std::string filex, filei;
     app.add_option("-x,--filex,--fileX", filex,
                    "Feature file name")
         ->required()->check(CLI::ExistingFile);
     app.add_option("-i,--filei,--fileI", filei,
                    "Initial cluster centers file name")
         ->required()->check(CLI::ExistingFile);
-    app.add_option("-t,--filet,--fileT", filet,
-                   "Absolute threshold file name")
+
+    double tol = 0.;
+    app.add_option("-t,--tol", tol, "Absolute threshold")
         ->required()->check(CLI::ExistingFile);
 
     int data_multiplier = 100;
@@ -115,8 +116,7 @@ int main(int argc, char *argv[]) {
     // Load data
     struct npyarr *arrX = load_npy(filex.c_str());
     struct npyarr *arrX_init = load_npy(filei.c_str());
-    struct npyarr *arrX_tol = load_npy(filet.c_str());
-    if (!arrX || !arrX_init || !arrX_tol) {
+    if (!arrX || !arrX_init) {
         std::cerr << "Failed to load input arrays" << std::endl;
         return EXIT_FAILURE;
     }
@@ -130,12 +130,6 @@ int main(int argc, char *argv[]) {
             << arrX_init->shape_len << std::endl;
         return EXIT_FAILURE;
     }
-    if (arrX_tol->shape_len != 0) {
-        std::cerr << "Expected 0 dimensions for X_tol, found "
-            << arrX_tol->shape_len << std::endl;
-        return EXIT_FAILURE;
-    }
-    double tol = ((double *) arrX_tol->data)[0];
 
     // Infer data size from loaded arrays
     std::ostringstream stringSizeStream;

--- a/native/linear_bench.cpp
+++ b/native/linear_bench.cpp
@@ -53,21 +53,11 @@ int main(int argc, char *argv[]) {
     std::string stringSize = "1000000x50";
     app.add_option("-s,--size", stringSize, "Problem size");
 
-    int fit_samples = 1;
-    app.add_option("--fit-samples", fit_samples,
-                   "Number of samples to report (fit)");
+    struct timing_options fit_opts = {100, 100, 10., 10};
+    add_timing_args(app, "fit", fit_opts);
 
-    int fit_reps = 10;
-    app.add_option("--fit-reps", fit_reps,
-                   "Number of repetitions in each sample (fit)");
-
-    int predict_samples = 1;
-    app.add_option("--predict-samples", predict_samples,
-                   "Number of samples to report (predict)");
-
-    int predict_reps = 10;
-    app.add_option("--predict-reps", predict_reps,
-                   "Number of repetitions in each sample (predict)");
+    struct timing_options predict_opts = {10, 100, 10., 10};
+    add_timing_args(app, "predict", predict_opts);
 
     CLI11_PARSE(app, argc, argv);
 
@@ -96,24 +86,16 @@ int main(int argc, char *argv[]) {
 
     double time;
     dal::training::ResultPtr training_result;
-    for (int i = 0; i < fit_samples; i++) {
-        auto pair = time_min<dal::training::ResultPtr> ([=] {
-                    return linear_fit_test(X, y, size[0], size[1]);
-                }, fit_reps);
-        time = pair.first;
-        training_result = pair.second;
-        std::cout << meta_info << "Linear.fit," << time << std::endl;
-    }
+    std::tie(time, training_result) = time_min<dal::training::ResultPtr> ([=] {
+            return linear_fit_test(X, y, size[0], size[1]);
+        }, fit_opts, verbose);
+    std::cout << meta_info << "Linear.fit," << time << std::endl;
 
     dm::NumericTablePtr predict_result;
-    for (int i = 0; i < predict_samples; i++) {
-        auto pair = time_min<dm::NumericTablePtr> ([=] {
-                    return linear_predict_test(training_result, Xp, size[0], size[1]);
-                }, predict_reps);
-        time = pair.first;
-        // predict_result = pair.second;
-        std::cout << meta_info << "Linear.predict," << time << std::endl;
-    }
+    std::tie(time, predict_result) = time_min<dm::NumericTablePtr> ([=] {
+            return linear_predict_test(training_result, Xp, size[0], size[1]);
+        }, predict_opts, verbose);
+    std::cout << meta_info << "Linear.predict," << time << std::endl;
     return 0;
 
 }

--- a/native/log_reg_lbfgs_bench.cpp
+++ b/native/log_reg_lbfgs_bench.cpp
@@ -14,6 +14,7 @@
 
 #define DAAL_DATA_TYPE double
 #include "CLI11.hpp"
+#include "common.hpp"
 #include "daal.h"
 #include "mkl.h"
 #include "npyfile.h"
@@ -158,6 +159,8 @@ print_numeric_table(dm::NumericTablePtr X_nt, std::string label)
     dm::BlockDescriptor<double> blockX;
     X_nt->getBlockOfRows(0, n_rows, dm::readOnly, blockX);
 
+    std::streamsize prec = std::cout.precision();
+
     double *x = blockX.getBlockPtr();
     std::cout << "@ " << label << ":" << std::endl;
     std::cout << std::setprecision(18) << std::scientific;
@@ -166,52 +169,70 @@ print_numeric_table(dm::NumericTablePtr X_nt, std::string label)
 	for(size_t i_inner=0; i_inner < n_cols; i_inner++) {
 	    std::cout << x[i_inner + i_outer * n_cols] << ", ";
 	}
-	std::cout << std::endl;
+	std::cout << std::setprecision(prec) << std::defaultfloat << std::endl;
     }
 
     X_nt->releaseBlockOfRows(blockX);
 }
 
-void
-bench(
-    size_t threadNum,
-    const std::string& X_fname,
-    const std::string& y_fname,
-    int fit_samples,
-    int fit_repetitions,
-    int predict_samples,
-    int predict_repetitions,
-    bool verbose,
-    bool header)
-{
-    /* Set MKL threading layer to TBB to match DAAL's default */
-    mkl_set_threading_layer(MKL_THREADING_TBB);
+int main(int argc, char** argv) {
 
-    /* Set the maximum number of threads to be used by the library */
-    if (threadNum != 0)
-        daal::services::Environment::getInstance()->setNumberOfThreads(threadNum);
+    CLI::App app("Native benchmark code for Intel(R) DAAL logistic regression classifier");
 
-    size_t daal_thread_num = daal::services::Environment::getInstance()->getNumberOfThreads();
+    std::string batch, arch, prefix;
+    int num_threads;
+    bool header, verbose;
+    add_common_args(app, batch, arch, prefix, num_threads, header, verbose);
+
+    std::string xfn = "./data/mX.csv";
+    app.add_option("-x,--fileX", xfn, "Feature file name")
+        ->required()
+        ->check(CLI::ExistingFile);
+
+    std::string yfn = "./data/mY.csv";
+    app.add_option("-y,--fileY", yfn, "Labels file name")
+        ->required()
+        ->check(CLI::ExistingFile);
+
+    struct timing_options fit_opts = {100, 100, 10., 10};
+    add_timing_args(app, "fit", fit_opts);
+
+    struct timing_options predict_opts = {10, 100, 10., 10};
+    add_timing_args(app, "predict", predict_opts);
+
+    double C = 1.0;
+    app.add_option("-C,--C", C, "Slack parameter")
+        ->check(CLI::PositiveNumber);
+
+    double tol = 1e-10;
+    app.add_option("--tol", tol, "Tolerance")
+        ->check(CLI::PositiveNumber);
+
+    size_t max_iter = 1000;
+    app.add_option("--maxiter", max_iter,
+                   "Maximum iterations for the iterative solver")
+        ->check(CLI::PositiveNumber);
+
+    // TODO add configurable fit_intercept parameter
+
+    CLI11_PARSE(app, argc, argv);
 
     /* Load data */
-    struct npyarr *arrX = load_npy(X_fname.c_str());
-    struct npyarr *arrY = load_npy(y_fname.c_str());
+    struct npyarr *arrX = load_npy(xfn.c_str());
+    struct npyarr *arrY = load_npy(yfn.c_str());
     if (!arrX || !arrY) {
         std::cerr << "Failed to load input arrays" << std::endl;
-        std::exit(1);
-        return;
+        return EXIT_FAILURE;
     }
     if (arrX->shape_len != 2) {
         std::cerr << "Expected 2 dimensions for X, found "
             << arrX->shape_len << std::endl;
-        std::exit(1);
-        return;
+        return EXIT_FAILURE;
     }
     if (arrY->shape_len != 1) {
         std::cerr << "Expected 1 dimension for y, found "
             << arrY->shape_len << std::endl;
-        std::exit(1);
-        return;
+        return EXIT_FAILURE;
     }
 
     /* Create numeric tables */
@@ -220,110 +241,63 @@ bench(
     dm::NumericTablePtr Y_nt = dm::HomogenNumericTable<int64_t>::create(
             (int64_t *) arrY->data, 1, arrY->shape[0]);
 
-    int n_classes = find_nClasses(Y_nt);
-    size_t max_iter = 1000;
-    double tol = 1e-10;
-    double C = 1.0;
+    size_t n_rows = Y_nt->getNumberOfRows();
+    size_t n_features = X_nt->getNumberOfColumns();
+    std::ostringstream string_size_stream;
+    string_size_stream << n_rows << 'x' << n_features;
+    std::string stringSize = string_size_stream.str();
+
+    // Set DAAL and MKL threads
+    int daal_threads = set_threads(num_threads);
+    mkl_set_threading_layer(MKL_THREADING_TBB);
+
+    int n_classes = count_classes(Y_nt);
     bool fit_intercept = true;
 
-    std::vector<std::chrono::duration<double> > fit_times;
+    // Prepare header and metadata info
+    std::string header_string = "batch,arch,prefix,threads,size,classes,"
+                                "solver,tol,maxiter,C,function,accuracy,time";
+    std::ostringstream meta_info_stream;
+    meta_info_stream
+        << batch << ','
+        << arch << ','
+        << prefix << ','
+        << daal_threads << ','
+        << stringSize << ','
+        << n_classes << ','
+        << "lbfgs" << ','
+        << tol << ','
+        << max_iter << ','
+        << C << ',';
+    std::string meta_info = meta_info_stream.str();
+
+    // Actually time benchmarks
+
+    double time;
+    bool verbose_fit = true;
     dl::training::ResultPtr training_result;
-    for(int i = 0; i < fit_samples; i++) {
-        auto start = std::chrono::system_clock::now();
-	for(int j=0; j < fit_repetitions; j++) {
-	    training_result = logistic_regression_fit(
-		n_classes, fit_intercept, C, max_iter, tol,
-		X_nt, Y_nt, verbose && (!i) && (!j)
-		);
-	}
-        auto finish = std::chrono::system_clock::now();
-        fit_times.push_back(finish - start);
-    }
-  
-    std::vector<std::chrono::duration<double> > predict_times;
-    dm::NumericTablePtr Yp_nt;
-    for(int i=0; i < predict_samples; i++) {
-        auto start = std::chrono::system_clock::now();
-        for(int j=0; j < predict_repetitions; j++) {
-	    Yp_nt = logistic_regression_predict(
-		n_classes, training_result,
-		X_nt, verbose && (!i) && (!j));
-	}
-        auto finish = std::chrono::system_clock::now();
-        predict_times.push_back(finish - start);
-
-    }
-
-    size_t n_rows = Y_nt->getNumberOfRows();
-    size_t equal_counter = count_same_labels(Y_nt, Yp_nt, n_rows);
-    double accuracy = ((double) equal_counter / (double) n_rows) * 100.00;
+    std::tie(time, training_result) = time_min<dl::training::ResultPtr> ([&] {
+            auto r = logistic_regression_fit(n_classes, fit_intercept, C,
+                                             max_iter, tol, X_nt, Y_nt,
+                                             verbose_fit);
+            verbose_fit = false;
+            return r;
+        }, fit_opts, verbose);
 
     if (header) {
-	std::cout << 
-        ""  << "prefix_ID"     <<
-        "," << "function"      <<
-        "," << "solver"        <<
-	    "," << "threads"       <<
-	    "," << "rows"          <<
-	    "," << "features"      <<
-	    "," << "fit"           <<
-	    "," << "predict"       <<
-	    "," << "accuracy"      <<
-	    "," << "classes"       << std::endl;
+        std::cout << header_string << std::endl;
     }
+    std::cout << meta_info << "LogReg.fit,," << time << std::endl;
 
-    std::cout << "Native-C,log_reg,lbfgs," << daal_thread_num;
-    std::cout << "," << X_nt->getNumberOfRows() << 
-	         "," << X_nt->getNumberOfColumns();
-    std::cout << "," << std::min_element(fit_times.begin(), fit_times.end())->count() / fit_repetitions;
-    std::cout << "," << std::min_element(predict_times.begin(), predict_times.end())->count() / predict_repetitions;
-    std::cout << "," << accuracy;
-    std::cout << "," << n_classes; // number of classes
-    std::cout << std::endl;
-}
+    dm::NumericTablePtr Yp_nt;
+    std::tie(time, Yp_nt) = time_min<dm::NumericTablePtr> ([&] {
+            return logistic_regression_predict(n_classes, training_result,
+                                               X_nt, verbose);
+            }, predict_opts, verbose);
 
-int main(int argc, char** argv) {
-    CLI::App app("Native benchmark code for Intel(R) DAAL logistic regression classifier");
+    double accuracy = accuracy_score(Y_nt, Yp_nt) * 100.;
+    std::cout << meta_info << "LogReg.predict," << accuracy << ','
+        << time << std::endl;
 
-    std::string xfn = "./data/mX.csv";
-    CLI::Option *optX = app.add_option("--fileX", xfn, "Feature file name")->required()->check(CLI::ExistingFile);
-
-    std::string yfn = "./data/mY.csv";
-    CLI::Option *optY = app.add_option("--fileY", yfn, "Labels file name")->required()->check(CLI::ExistingFile);
-
-    int fit_samples = 3, fit_repetitions = 1, predict_samples = 5, predict_repetitions = 50;
-    CLI::Option *optFitS = app.add_option("--fit-samples", fit_samples, "Number of samples to collect for time of execution of repeated fit calls", true);
-    CLI::Option *optFitR = app.add_option("--fit-repetitions", fit_repetitions, "Number of repeated fit calls to time", true);
-    CLI::Option *optPredS = app.add_option("--predict-samples", predict_samples, "Number of samples to collect for time of execution of repeated predict calls", true);
-    CLI::Option *optPredR = app.add_option("--predict-repetitions", predict_repetitions, "Number of repeated predict calls to time", true);
-
-    int num_threads = 0;
-    CLI::Option *optNumThreads = app.add_option("-n,--num-threads", num_threads, "Number of threads for DAAL to use", true);
-
-    bool verbose = false;
-    CLI::Option *optVerbose = app.add_flag("-v,--verbose", verbose, "Whether to be verbose or terse");
-
-    bool header = false;
-    CLI::Option *optHeader = app.add_flag("--header", header, "Whether to output header");
-
-    CLI11_PARSE(app, argc, argv);
-
-    assert(num_threads >= 0);
-    assert(fit_samples > 0);
-    assert(fit_repetitions > 0);
-    assert(predict_samples > 0);
-    assert(predict_repetitions > 0);
-
-    if (verbose) {
-	std::clog << 
-	    "@ {FIT_SAMPLES: "        << fit_samples <<
-	    ", FIT_REPETIONS: "       << fit_repetitions <<
-	    ", PREDICT_SAMPLES: "     << predict_samples <<
-	    ", PREDICT_REPETITIONS: " << predict_repetitions << 
-	    "}" << std::endl;
-    }
-
-    bench(num_threads, xfn, yfn, fit_samples, fit_repetitions, predict_samples, predict_repetitions, verbose, header);
-
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/native/svm_bench.cpp
+++ b/native/svm_bench.cpp
@@ -488,7 +488,7 @@ int main(int argc, char **argv) {
     size_t cache_size_mb = get_optimal_cache_size(n_rows) / 1048576;
     // Actual benchmark timing here:
 
-    bool verbose_fit = true;
+    bool verbose_fit = verbose;
     size_t sv_len = 0;
     double time;
     da::classifier::training::ResultPtr training_result;

--- a/native/svm_bench.cpp
+++ b/native/svm_bench.cpp
@@ -392,7 +392,6 @@ int main(int argc, char **argv) {
         ->required()
         ->check(CLI::ExistingFile);
 
-
     struct timing_options fit_opts = {100, 100, 10., 10};
     add_timing_args(app, "fit", fit_opts);
 

--- a/sklearn/bench.py
+++ b/sklearn/bench.py
@@ -93,10 +93,14 @@ def parse_args(parser, size=None, dtypes=None, loop_types=(),
         else:
             loop_dash = loop_for = ''
 
-        parser.add_argument(f'--{loop_dash}inner-loops', default=3, type=int,
-                            help=f'Number of inner loop iterations {loop_for}'
+        parser.add_argument(f'--{loop_dash}inner-loops', default=100, type=int,
+                            help=f'Maximum inner loop iterations {loop_for}'
                                  f'(we take the mean over inner iterations)')
-        parser.add_argument(f'--{loop_dash}outer-loops', default=1, type=int,
+        parser.add_argument(f'--{loop_dash}outer-loops', default=100, type=int,
+                            help=f'Maximum outer loop iterations {loop_for}'
+                                 f'(we take the min over outer iterations)')
+        parser.add_argument(f'--{loop_dash}time-limit', default=10.,
+                            type=float,
                             help=f'Number of outer loop iterations {loop_for}'
                                  f'(we take the min over outer iterations)')
 
@@ -186,7 +190,8 @@ def prepare_daal(num_threads=-1):
     return num_threads, daal_version
 
 
-def time_mean_min(func, *args, inner_loops=1, outer_loops=1, **kwargs):
+def time_mean_min(func, *args, inner_loops=1, outer_loops=1, time_limit=10.,
+                  goal_outer_loops=10, warmup=True, verbose=True, **kwargs):
     '''
     Time the given function (inner_loops * outer_loops) times, returning the
     min of the inner loop means.
@@ -196,9 +201,19 @@ def time_mean_min(func, *args, inner_loops=1, outer_loops=1, **kwargs):
     func : callable f(*args, **kwargs)
         The function to time.
     inner_loops : int
-        Number of inner loop iterations to take the mean over.
+        Maximum number of inner loop iterations to take the mean over.
     outer_loops : int
-        Number of outer loop iterations to take the min over.
+        Maximum number of outer loop iterations to take the min over.
+    goal_outer_loops : int
+        Number of outer loop iterations to aim for, if using warmup.
+    time_limit : double
+        Number of seconds to aim for. If accumulated time exceeds time_limit
+        in outer loops, exit without running more outer loops. If zero,
+        disable time limit.
+    warmup : boolean
+        If True, run warm-up rounds to find optimal number of inner loops.
+    verbose : boolean
+        If True, print outer loop timings and miscellaneous information.
 
     Returns
     -------
@@ -212,6 +227,25 @@ def time_mean_min(func, *args, inner_loops=1, outer_loops=1, **kwargs):
         'Must time the function at least once'
 
     times = np.zeros(outer_loops, dtype='f8')
+    total_time = 0.
+
+    # Warm-up iterations to determine optimal inner_loops
+    warmup_time = 0.
+    last_warmup = 0.
+    if warmup:
+        for _ in range(inner_loops):
+            t0 = timeit.default_timer()
+            func(*args, **kwargs)
+            t1 = timeit.default_timer()
+
+            warmup_time += t1 - t0
+            last_warmup = t1 - t0
+            if warmup_time > time_limit / 10:
+                break
+
+        inner_loops = max(1, int(time_limit / last_warmup / goal_outer_loops))
+        logverbose(f'Optimal inner loops = {inner_loops}', verbose)
+
 
     for i in range(outer_loops):
 
@@ -221,12 +255,30 @@ def time_mean_min(func, *args, inner_loops=1, outer_loops=1, **kwargs):
         t1 = timeit.default_timer()
 
         times[i] = t1 - t0
+        total_time += times[i]
+
+        if time_limit > 0 and total_time > time_limit:
+            logverbose(f'TT={total_time:0.2f}s exceeding {time_limit}s '
+                       f'after iteration {i+1}', verbose)
+            outer_loops = i + 1
+            times = times[:outer_loops]
+            break
+
 
     # We take the mean of inner loop times
     times /= inner_loops
+    logverbose(f'Mean times [s]\n{times}', verbose)
 
     # We take the min of outer loop times
     return np.min(times), val
+
+
+def logverbose(msg, verbose):
+    '''
+    Print msg as a verbose logging message only if verbose is True
+    '''
+    if verbose:
+        print('@', msg)
 
 
 def accuracy_score(y, yp):

--- a/sklearn/bench.py
+++ b/sklearn/bench.py
@@ -245,8 +245,8 @@ def time_mean_min(func, *args, inner_loops=1, outer_loops=1, time_limit=10.,
             val = func(*args, **kwargs)
             t1 = timeit.default_timer()
 
-            warmup_time += t1 - t0
             last_warmup = t1 - t0
+            warmup_time += last_warmup
             if warmup_time > time_limit / 10:
                 break
 

--- a/sklearn/df_clsf.py
+++ b/sklearn/df_clsf.py
@@ -61,12 +61,18 @@ print_header(columns, params)
 # Time fit and predict
 fit_time, _ = time_mean_min(clf.fit, X, y,
                             outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops)
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
 print_row(columns, params, function='df_clsf.fit', time=fit_time)
 
 predict_time, y_pred = time_mean_min(clf.predict, X,
                                      outer_loops=params.predict_outer_loops,
-                                     inner_loops=params.predict_inner_loops)
+                                     inner_loops=params.predict_inner_loops,
+                                     goal_outer_loops=params.predict_goal,
+                                     time_limit=params.predict_time_limit,
+                                     verbose=params.verbose)
 acc = 100 * accuracy_score(y_pred, y)
 print_row(columns, params, function='df_clsf.predict', time=predict_time,
           accuracy=acc)

--- a/sklearn/df_regr.py
+++ b/sklearn/df_regr.py
@@ -58,10 +58,16 @@ print_header(columns, params)
 # Time fit and predict
 fit_time, _ = time_mean_min(regr.fit, X, y,
                             outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops)
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
 print_row(columns, params, function='df_regr.fit', time=fit_time)
 
 predict_time, y_pred = time_mean_min(regr.predict, X,
                                      outer_loops=params.predict_outer_loops,
-                                     inner_loops=params.predict_inner_loops)
+                                     inner_loops=params.predict_inner_loops,
+                                     goal_outer_loops=params.predict_goal,
+                                     time_limit=params.predict_time_limit,
+                                     verbose=params.verbose)
 print_row(columns, params, function='df_regr.predict', time=predict_time)

--- a/sklearn/distances.py
+++ b/sklearn/distances.py
@@ -24,5 +24,8 @@ for metric in params.metrics:
     time, _ = time_mean_min(pairwise_distances, X, metric=metric,
                             n_jobs=params.n_jobs,
                             outer_loops=params.outer_loops,
-                            inner_loops=params.inner_loops)
+                            inner_loops=params.inner_loops,
+                            goal_outer_loops=params.goal,
+                            time_limit=params.time_limit,
+                            verbose=params.verbose)
     print_row(columns, params, function=metric.capitalize(), time=time)

--- a/sklearn/kmeans.py
+++ b/sklearn/kmeans.py
@@ -41,11 +41,17 @@ print_header(columns, params)
 # Time fit
 fit_time, _ = time_mean_min(kmeans.fit, X,
                             outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops)
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
 print_row(columns, params, function='KMeans.fit', time=fit_time)
 
 # Time predict
 predict_time, _ = time_mean_min(kmeans.predict, X,
                                 outer_loops=params.predict_outer_loops,
-                                inner_loops=params.predict_inner_loops)
+                                inner_loops=params.predict_inner_loops,
+                                goal_outer_loops=params.predict_goal,
+                                time_limit=params.predict_time_limit,
+                                verbose=params.verbose)
 print_row(columns, params, function='KMeans.predict', time=predict_time)

--- a/sklearn/kmeans.py
+++ b/sklearn/kmeans.py
@@ -8,12 +8,12 @@ import numpy as np
 from sklearn.cluster import KMeans
 
 parser = argparse.ArgumentParser(description='scikit-learn K-means benchmark')
-parser.add_argument('-x', '--filex', '--fileX', '--input',
+parser.add_argument('-x', '--filex', '--fileX', '--input', required=True,
                     type=str, help='Points to cluster')
-parser.add_argument('-i', '--filei', '--fileI', '--init',
+parser.add_argument('-i', '--filei', '--fileI', '--init', required=True,
                     type=str, help='Initial clusters')
-# parser.add_argument('-t', '--filet', '--fileT', '--tol',
-#                     type=str, help='Absolute threshold')
+parser.add_argument('-t', '--tol', type=float, default=0.,
+                    help='Absolute threshold')
 parser.add_argument('-m', '--data-multiplier', default=100,
                     type=int, help='Data multiplier')
 parser.add_argument('--maxiter', type=int, default=100,
@@ -28,7 +28,7 @@ X_mult = np.vstack((X,) * params.data_multiplier)
 n_clusters = X_init.shape[0]
 
 # Create our clustering object
-kmeans = KMeans(n_clusters=n_clusters, n_jobs=params.n_jobs, tol=1e-16,
+kmeans = KMeans(n_clusters=n_clusters, n_jobs=params.n_jobs, tol=params.tol,
                 max_iter=params.maxiter, n_init=1, init=X_init)
 
 columns = ('batch', 'arch', 'prefix', 'function', 'threads', 'dtype', 'size',

--- a/sklearn/linear.py
+++ b/sklearn/linear.py
@@ -31,11 +31,17 @@ print_header(columns, params)
 # Time fit
 fit_time, _ = time_mean_min(regr.fit, X, y,
                             outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops)
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
 print_row(columns, params, function='Linear.fit', time=fit_time)
 
 # Time predict
 predict_time, yp = time_mean_min(regr.predict, Xp,
                                  outer_loops=params.predict_outer_loops,
-                                 inner_loops=params.predict_inner_loops)
+                                 inner_loops=params.predict_inner_loops,
+                                 goal_outer_loops=params.predict_goal,
+                                 time_limit=params.predict_time_limit,
+                                 verbose=params.verbose)
 print_row(columns, params, function='Linear.predict', time=predict_time)

--- a/sklearn/log_reg.py
+++ b/sklearn/log_reg.py
@@ -65,12 +65,18 @@ print_header(columns, params)
 # Time fit and predict
 fit_time, _ = time_mean_min(clf.fit, X, y,
                             outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops)
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
 print_row(columns, params, function='LogReg.fit', time=fit_time)
 
 predict_time, y_pred = time_mean_min(clf.predict, X,
                                      outer_loops=params.predict_outer_loops,
-                                     inner_loops=params.predict_inner_loops)
+                                     inner_loops=params.predict_inner_loops,
+                                     goal_outer_loops=params.predict_goal,
+                                     time_limit=params.predict_time_limit,
+                                     verbose=params.verbose)
 acc = 100 * accuracy_score(y_pred, y)
 print_row(columns, params, function='LogReg.predict', time=predict_time,
           accuracy=acc)

--- a/sklearn/pca.py
+++ b/sklearn/pca.py
@@ -36,11 +36,17 @@ print_header(columns, params)
 # Time fit
 fit_time, _ = time_mean_min(pca.fit, X,
                             outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops)
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
 print_row(columns, params, function='PCA.fit', time=fit_time)
 
 # Time transform
 transform_time, _ = time_mean_min(pca.transform, Xp,
                                   outer_loops=params.transform_outer_loops,
-                                  inner_loops=params.transform_inner_loops)
+                                  inner_loops=params.transform_inner_loops,
+                                  goal_outer_loops=params.transform_goal,
+                                  time_limit=params.transform_time_limit,
+                                  verbose=params.verbose)
 print_row(columns, params, function='PCA.transform', time=transform_time)

--- a/sklearn/ridge.py
+++ b/sklearn/ridge.py
@@ -34,11 +34,17 @@ print_header(columns, params)
 # Time fit
 fit_time, _ = time_mean_min(regr.fit, X, y,
                             outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops)
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
 print_row(columns, params, function='Ridge.fit', time=fit_time)
 
 # Time predict
 predict_time, yp = time_mean_min(regr.predict, Xp,
                                  outer_loops=params.predict_outer_loops,
-                                 inner_loops=params.predict_inner_loops)
+                                 inner_loops=params.predict_inner_loops,
+                                 goal_outer_loops=params.predict_goal,
+                                 time_limit=params.predict_time_limit,
+                                 verbose=params.verbose)
 print_row(columns, params, function='Ridge.predict', time=predict_time)

--- a/sklearn/svm.py
+++ b/sklearn/svm.py
@@ -86,13 +86,19 @@ print_header(columns, params)
 # Time fit and predict
 fit_time, _ = time_mean_min(clf.fit, X, y,
                             outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops)
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
 params.sv_len = clf.support_.shape[0]
 print_row(columns, params, function='SVM.fit', time=fit_time)
 
 predict_time, y_pred = time_mean_min(clf.predict, X,
                                      outer_loops=params.predict_outer_loops,
-                                     inner_loops=params.predict_inner_loops)
+                                     inner_loops=params.predict_inner_loops,
+                                     goal_outer_loops=params.predict_goal,
+                                     time_limit=params.predict_time_limit,
+                                     verbose=params.verbose)
 acc = 100 * accuracy_score(y_pred, y)
 print_row(columns, params, function='SVM.predict', time=predict_time,
           accuracy=acc)


### PR DESCRIPTION
On certain benchmarks, the predict method completes orders of magnitude faster than the fit method. Instead of requiring the user to manually select number of repetitions to run, this PR implements aiming for a certain target total time instead. This should help with measurement stability in these benchmarks.

The timing function first takes some "warmup" measurements and determines a good number of inner loops such that the total timing meets the overall time limit and includes about `--goal-outer-loops` outer loops. If the warmup measurement time exceeds the time limit, the timing function just returns the warmup time.

This PR also includes some refactoring of native benchmarks to use common functions for counting classes, printing tables, and timing.

One other change made here is to use `tol=0` in all kmeans benchmarks unless otherwise specified on the command-line. This removes randomness in number of iterations in K-Means fit.