### PR TITLE
Add DBSCAN benchmarks

### DIFF
--- a/daal4py/dbscan.py
+++ b/daal4py/dbscan.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2017-2019 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import argparse
+from bench import parse_args, time_mean_min, print_header, print_row, size_str
+from daal4py import dbscan
+from daal4py.sklearn.utils import getFPType
+import numpy as np
+
+parser = argparse.ArgumentParser(description='daal4py DBSCAN clustering '
+                                             'benchmark')
+parser.add_argument('-x', '--filex', '--fileX', '--input', required=True,
+                    type=str, help='Points to cluster')
+parser.add_argument('-e', '--eps', '--epsilon', type=float, default=10,
+                    help='Radius of neighborhood of a point')
+parser.add_argument('-m', '--data-multiplier', default=100,
+                    type=int, help='Data multiplier')
+parser.add_argument('-M', '--min-samples', default=5, type=int,
+                    help='The minimum number of samples required in a '
+                    'neighborhood to consider a point a core point')
+params = parse_args(parser, prefix='daal4py')
+
+# Load generated data
+X = np.load(params.filex)
+X_mult = np.vstack((X,) * params.data_multiplier)
+
+params.size = size_str(X.shape)
+params.dtype = X.dtype
+
+
+# Define functions to time
+def test_dbscan(X):
+    algorithm = dbscan(
+        fptype=getFPType(X),
+        epsilon=params.eps,
+        minObservations=params.min_samples,
+        resultsToCompute='computeCoreIndices'
+    )
+    return algorithm.compute(X)
+
+
+columns = ('batch', 'arch', 'prefix', 'function', 'threads', 'dtype', 'size',
+           'n_clusters', 'time')
+print_header(columns, params)
+
+# Time clustering
+time, result = time_mean_min(test_dbscan, X,
+                             outer_loops=params.outer_loops,
+                             inner_loops=params.inner_loops,
+                             goal_outer_loops=params.goal,
+                             time_limit=params.time_limit,
+                             verbose=params.verbose)
+params.n_clusters = result.nClusters[0, 0]
+print_row(columns, params, function='DBSCAN', time=time)

--- a/daal4py/dbscan.py
+++ b/daal4py/dbscan.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -12,18 +12,15 @@ parser = argparse.ArgumentParser(description='daal4py DBSCAN clustering '
                                              'benchmark')
 parser.add_argument('-x', '--filex', '--fileX', '--input', required=True,
                     type=str, help='Points to cluster')
-parser.add_argument('-e', '--eps', '--epsilon', type=float, default=10,
+parser.add_argument('-e', '--eps', '--epsilon', type=float, default=10.,
                     help='Radius of neighborhood of a point')
-parser.add_argument('-m', '--data-multiplier', default=100,
-                    type=int, help='Data multiplier')
-parser.add_argument('-M', '--min-samples', default=5, type=int,
+parser.add_argument('-m', '--min-samples', default=5, type=int,
                     help='The minimum number of samples required in a '
                     'neighborhood to consider a point a core point')
 params = parse_args(parser, prefix='daal4py')
 
 # Load generated data
 X = np.load(params.filex)
-X_mult = np.vstack((X,) * params.data_multiplier)
 
 params.size = size_str(X.shape)
 params.dtype = X.dtype

--- a/native/Makefile
+++ b/native/Makefile
@@ -1,9 +1,9 @@
-# Copyright (C) 2018 Intel Corporation
+# Copyright (C) 2018-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
 BENCHMARKS += distances kmeans linear ridge pca svm log_reg_lbfgs \
-	      decision_forest_regr decision_forest_clsf
+	      decision_forest_regr decision_forest_clsf dbscan
 FOBJ = $(addprefix lbfgsb/,lbfgsb.o linpack.o timer.o)
 CXXSRCS = $(addsuffix _bench.cpp,$(BENCHMARKS))
 

--- a/native/common.hpp
+++ b/native/common.hpp
@@ -420,7 +420,8 @@ void print_numeric_table(dm::NumericTablePtr X_nt, std::string label) {
         }
         std::cout << std::endl;
     }
-	std::cout << std::setprecision(prec) << std::defaultfloat;
+    std::cout << std::setprecision(prec);
+    std::cout.unsetf(std::ios_base::floatfield);
 
     X_nt->releaseBlockOfRows(blockX);
 

--- a/native/dbscan_bench.cpp
+++ b/native/dbscan_bench.cpp
@@ -110,7 +110,8 @@ int main(int argc, char *argv[]) {
     int n_clusters = n_clusters_block.getBlockPtr()[0];
     n_clusters_nt->releaseBlockOfRows(n_clusters_block);
 
-    std::cout << meta_info << "DBSCAN," << n_clusters << time << std::endl;
+    std::cout << meta_info << "DBSCAN," << n_clusters << ',' << time
+              << std::endl;
 
     return 0;
 }

--- a/native/dbscan_bench.cpp
+++ b/native/dbscan_bench.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <chrono>  
+
+#define DAAL_DATA_TYPE double
+#include "common.hpp"
+#include "CLI11.hpp"
+#include "daal.h"
+#include "npyfile.h"
+
+
+da::dbscan::ResultPtr
+dbscan_test(dm::NumericTablePtr X_nt, double eps, int min_samples) {
+
+    da::dbscan::Batch<double> algorithm(eps, min_samples);
+    algorithm.input.set(da::dbscan::data, X_nt);
+    algorithm.compute();
+
+    return algorithm.getResult();
+
+}
+
+
+int main(int argc, char *argv[]) {
+
+    CLI::App app("Native benchmark for Intel(R) DAAL DBSCAN clustering");
+
+    std::string batch, arch, prefix;
+    int num_threads;
+    bool header, verbose;
+    add_common_args(app, batch, arch, prefix, num_threads, header, verbose);
+
+    struct timing_options timing_opts = {100, 100, 10., 10};
+    add_timing_args(app, "", timing_opts);
+
+    std::string filex, filei;
+    app.add_option("-x,--filex,--fileX", filex,
+                   "Feature file name")
+        ->required()->check(CLI::ExistingFile);
+
+    double eps = 10.;
+    app.add_option("-e,--eps,--epsilon", eps,
+                   "Radius of neighborhood of a point");
+
+    int min_samples = 5;
+    app.add_option("-m,--min-samples", min_samples,
+                   "The minimum number of samples required in a neighborhood "
+                   "to consider a point a core point");
+
+    CLI11_PARSE(app, argc, argv);
+
+    // Set DAAL thread count
+    int daal_threads = set_threads(num_threads);
+
+    // Load data
+    struct npyarr *arrX = load_npy(filex.c_str());
+    if (!arrX) {
+        std::cerr << "Failed to load input array" << std::endl;
+        return EXIT_FAILURE;
+    }
+    if (arrX->shape_len != 2) {
+        std::cerr << "Expected 2 dimensions for X, found "
+            << arrX->shape_len << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Infer data size from loaded arrays
+    std::ostringstream stringSizeStream;
+    stringSizeStream << arrX->shape[0] << 'x' << arrX->shape[1];
+    std::string stringSize = stringSizeStream.str();
+
+    // Create numeric tables from input data
+    dm::NumericTablePtr X_nt = make_table((double *) arrX->data,
+                                          arrX->shape[0],
+                                          arrX->shape[1]);
+
+    // Prepare meta-info
+    std::string header_string = "Batch,Arch,Prefix,Threads,Size,Function,"
+                                "Clusters,Time";
+    std::ostringstream meta_info_stream;
+    meta_info_stream
+        << batch << ','
+        << arch << ','
+        << prefix << ','
+        << daal_threads << ','
+        << stringSize << ',';
+    std::string meta_info = meta_info_stream.str();
+
+    // Actually time benches
+    double time;
+    da::dbscan::ResultPtr dbscan_result;
+    std::tie(time, dbscan_result) = time_min<da::dbscan::ResultPtr> ([=] {
+                return dbscan_test(X_nt, eps, min_samples);
+            }, timing_opts, verbose);
+
+    // Get number of clusters found
+    dm::NumericTablePtr n_clusters_nt
+        = dbscan_result->get(da::dbscan::nClusters);
+    dm::BlockDescriptor<int> n_clusters_block;
+    n_clusters_nt->getBlockOfRows(0, 1, dm::readOnly, n_clusters_block);
+    int n_clusters = n_clusters_block.getBlockPtr()[0];
+    n_clusters_nt->releaseBlockOfRows(n_clusters_block);
+
+    std::cout << meta_info << "DBSCAN," << n_clusters << time << std::endl;
+
+    return 0;
+}
+

--- a/sklearn/bench.py
+++ b/sklearn/bench.py
@@ -121,7 +121,7 @@ def parse_args(parser, size=None, dtypes=None, loop_types=(),
 
     n_jobs = None
     if n_jobs_supported and not daal_version:
-        n_jobs = num_threads = params.num_threads
+        n_jobs = num_threads = params.threads
 
     # Set threading and DAAL related params here
     setattr(params, 'threads', num_threads)

--- a/sklearn/dbscan.py
+++ b/sklearn/dbscan.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2017-2019 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import argparse
+from bench import parse_args, time_mean_min, print_header, print_row, size_str
+import numpy as np
+from sklearn.cluster import DBSCAN
+
+parser = argparse.ArgumentParser(description='scikit-learn DBSCAN benchmark')
+parser.add_argument('-x', '--filex', '--fileX', '--input', required=True,
+                    type=str, help='Points to cluster')
+parser.add_argument('-e', '--eps', '--epsilon', type=float, default=0.5,
+                    help='Radius of neighborhood of a point')
+parser.add_argument('-m', '--data-multiplier', default=100,
+                    type=int, help='Data multiplier')
+parser.add_argument('-M', '--min-samples', default=5, type=int,
+                    help='The minimum number of samples required in a '
+                    'neighborhood to consider a point a core point')
+params = parse_args(parser, loop_types=('fit', 'predict'), n_jobs_supported=True)
+
+# Load generated data
+X = np.load(params.filex)
+X_mult = np.vstack((X,) * params.data_multiplier)
+
+# Create our clustering object
+dbscan = DBSCAN(eps=params.eps, n_jobs=params.n_jobs,
+                min_samples=params.min_samples, metric='euclidean',
+                algorithm='auto')
+
+# N.B. algorithm='auto' will select DAAL's brute force method when running
+# daal4py-patched scikit-learn.
+
+columns = ('batch', 'arch', 'prefix', 'function', 'threads', 'dtype', 'size',
+           'n_clusters', 'time')
+params.size = size_str(X.shape)
+params.dtype = X.dtype
+print_header(columns, params)
+
+# Time fit
+fit_time, _ = time_mean_min(dbscan.fit, X,
+                            outer_loops=params.fit_outer_loops,
+                            inner_loops=params.fit_inner_loops,
+                            goal_outer_loops=params.fit_goal,
+                            time_limit=params.fit_time_limit,
+                            verbose=params.verbose)
+params.n_clusters = len(dbscan.core_sample_indices_)
+print_row(columns, params, function='DBSCAN.fit', time=fit_time)
+
+# Time predict
+predict_time, _ = time_mean_min(dbscan.fit_predict, X,
+                                outer_loops=params.predict_outer_loops,
+                                inner_loops=params.predict_inner_loops,
+                                goal_outer_loops=params.predict_goal,
+                                time_limit=params.predict_time_limit,
+                                verbose=params.verbose)
+print_row(columns, params, function='DBSCAN.fit_predict', time=predict_time)

--- a/sklearn/dbscan.py
+++ b/sklearn/dbscan.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2019 Intel Corporation
+# Copyright (C) 2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 
@@ -10,18 +10,15 @@ from sklearn.cluster import DBSCAN
 parser = argparse.ArgumentParser(description='scikit-learn DBSCAN benchmark')
 parser.add_argument('-x', '--filex', '--fileX', '--input', required=True,
                     type=str, help='Points to cluster')
-parser.add_argument('-e', '--eps', '--epsilon', type=float, default=10,
+parser.add_argument('-e', '--eps', '--epsilon', type=float, default=10.,
                     help='Radius of neighborhood of a point')
-parser.add_argument('-m', '--data-multiplier', default=100,
-                    type=int, help='Data multiplier')
-parser.add_argument('-M', '--min-samples', default=5, type=int,
+parser.add_argument('-m', '--min-samples', default=5, type=int,
                     help='The minimum number of samples required in a '
                     'neighborhood to consider a point a core point')
 params = parse_args(parser, n_jobs_supported=True)
 
 # Load generated data
 X = np.load(params.filex)
-X_mult = np.vstack((X,) * params.data_multiplier)
 
 # Create our clustering object
 dbscan = DBSCAN(eps=params.eps, n_jobs=params.n_jobs,
@@ -29,7 +26,8 @@ dbscan = DBSCAN(eps=params.eps, n_jobs=params.n_jobs,
                 algorithm='auto')
 
 # N.B. algorithm='auto' will select DAAL's brute force method when running
-# daal4py-patched scikit-learn.
+# daal4py-patched scikit-learn, and probably 'kdtree' when running unpatched
+# scikit-learn.
 
 columns = ('batch', 'arch', 'prefix', 'function', 'threads', 'dtype', 'size',
            'n_clusters', 'time')

--- a/sklearn/dbscan.py
+++ b/sklearn/dbscan.py
@@ -10,14 +10,14 @@ from sklearn.cluster import DBSCAN
 parser = argparse.ArgumentParser(description='scikit-learn DBSCAN benchmark')
 parser.add_argument('-x', '--filex', '--fileX', '--input', required=True,
                     type=str, help='Points to cluster')
-parser.add_argument('-e', '--eps', '--epsilon', type=float, default=0.5,
+parser.add_argument('-e', '--eps', '--epsilon', type=float, default=10,
                     help='Radius of neighborhood of a point')
 parser.add_argument('-m', '--data-multiplier', default=100,
                     type=int, help='Data multiplier')
 parser.add_argument('-M', '--min-samples', default=5, type=int,
                     help='The minimum number of samples required in a '
                     'neighborhood to consider a point a core point')
-params = parse_args(parser, loop_types=('fit', 'predict'), n_jobs_supported=True)
+params = parse_args(parser, n_jobs_supported=True)
 
 # Load generated data
 X = np.load(params.filex)
@@ -38,20 +38,12 @@ params.dtype = X.dtype
 print_header(columns, params)
 
 # Time fit
-fit_time, _ = time_mean_min(dbscan.fit, X,
-                            outer_loops=params.fit_outer_loops,
-                            inner_loops=params.fit_inner_loops,
-                            goal_outer_loops=params.fit_goal,
-                            time_limit=params.fit_time_limit,
-                            verbose=params.verbose)
-params.n_clusters = len(dbscan.core_sample_indices_)
-print_row(columns, params, function='DBSCAN.fit', time=fit_time)
-
-# Time predict
-predict_time, _ = time_mean_min(dbscan.fit_predict, X,
-                                outer_loops=params.predict_outer_loops,
-                                inner_loops=params.predict_inner_loops,
-                                goal_outer_loops=params.predict_goal,
-                                time_limit=params.predict_time_limit,
-                                verbose=params.verbose)
-print_row(columns, params, function='DBSCAN.fit_predict', time=predict_time)
+time, _ = time_mean_min(dbscan.fit, X,
+                        outer_loops=params.outer_loops,
+                        inner_loops=params.inner_loops,
+                        goal_outer_loops=params.goal,
+                        time_limit=params.time_limit,
+                        verbose=params.verbose)
+labels = dbscan.labels_
+params.n_clusters = len(set(labels)) - (1 if -1 in labels else 0)
+print_row(columns, params, function='DBSCAN', time=time)


### PR DESCRIPTION
@oleksandr-pavlyk 

This PR adds native, sklearn, and daal4py implementations of DBSCAN benchmarks, usable with kmeans clustering data when given epsilon=10.