### PR TITLE
Train test split benchmarks

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -177,6 +177,43 @@
             "kernel": ["rbf"]
         },
         {
+            "lib": ["sklearn"],
+            "algorithm": "train_test_split",
+            "dataset": [
+                {
+                    "source": "synthetic",
+                    "type": "classification",
+                    "n_classes": 2,
+                    "n_features": 20,
+                    "training": {
+                        "n_samples": 500000
+                    }
+                },
+                {
+                    "source": "synthetic",
+                    "type": "classification",
+                    "n_classes": 2,
+                    "n_features": 100,
+                    "training": {
+                        "n_samples": 100000
+                    }
+                },
+                {
+                    "source": "synthetic",
+                    "type": "classification",
+                    "n_classes": 2,
+                    "n_features": 5000,
+                    "training": {
+                        "n_samples": 5000
+                    }
+                }
+            ],
+            "shuffle": [""],
+            "include-y": [""],
+            "train-size": [0.75],
+            "test-size": [0.25]
+        },
+        {
             "lib": ["xgboost"],
             "algorithm": "gbt",
             "dataset": [

--- a/config_example.json
+++ b/config_example.json
@@ -177,42 +177,6 @@
             "kernel": ["rbf"]
         },
         {
-            "lib": ["sklearn"],
-            "algorithm": "train_test_split",
-            "dataset": [
-                {
-                    "source": "synthetic",
-                    "type": "classification",
-                    "n_classes": 2,
-                    "n_features": 20,
-                    "training": {
-                        "n_samples": 500000
-                    }
-                },
-                {
-                    "source": "synthetic",
-                    "type": "classification",
-                    "n_classes": 2,
-                    "n_features": 100,
-                    "training": {
-                        "n_samples": 100000
-                    }
-                },
-                {
-                    "source": "synthetic",
-                    "type": "classification",
-                    "n_classes": 2,
-                    "n_features": 5000,
-                    "training": {
-                        "n_samples": 5000
-                    }
-                }
-            ],
-            "include-y": [""],
-            "train-size": [0.75],
-            "test-size": [0.25]
-        },
-        {
             "lib": ["xgboost"],
             "algorithm": "gbt",
             "dataset": [

--- a/config_example.json
+++ b/config_example.json
@@ -208,7 +208,6 @@
                     }
                 }
             ],
-            "shuffle": [""],
             "include-y": [""],
             "train-size": [0.75],
             "test-size": [0.25]

--- a/cuml/train_test_split.py
+++ b/cuml/train_test_split.py
@@ -4,33 +4,20 @@
 
 import argparse
 from bench import measure_function_time, parse_args, load_data, print_output
-from sklearn.model_selection import train_test_split
+from cuml import train_test_split
 
 parser = argparse.ArgumentParser(
-    description='scikit-learn train_test_split benchmark')
+    description='cuml train_test_split benchmark')
 parser.add_argument('--train-size', type=float, default=0.75,
                     help='Size of training subset')
 parser.add_argument('--test-size', type=float, default=0.25,
                     help='Size of testing subset')
 parser.add_argument('--shuffle', default=False, action='store_true',
                     help='Perform data shuffle before splitting')
-parser.add_argument('--include-y', default=False, action='store_true',
-                    help='Include label (Y) in splitting')
-parser.add_argument('--rng', default=None,
-                    choices=('MT19937', 'SFMT19937', 'MT2203', 'R250', 'WH',
-                             'MCG31', 'MCG59', 'MRG32K3A', 'PHILOX4X32X10',
-                             'NONDETERM', None),
-                    help='Random numbers generator for shuffling '
-                         '(only for IDP scikit-learn)')
 params = parse_args(parser)
 
 # Load generated data
 X, y, _, _ = load_data(params)
-
-if params.include_y:
-    data_args = (X, y)
-else:
-    data_args = (X, )
 
 tts_params = {
     'train_size': params.train_size,
@@ -39,16 +26,12 @@ tts_params = {
     'random_state': params.seed
 }
 
-if params.rng is not None:
-    tts_params['rng'] = params.rng
-
-time, _ = measure_function_time(train_test_split, *data_args, **tts_params,
-                                params=params)
+time, _ = measure_function_time(train_test_split, X=X, y=y, params=params)
 
 columns = ('batch', 'arch', 'prefix', 'function', 'threads', 'dtype', 'size',
            'time')
 
-print_output(library='sklearn', algorithm='train_test_split',
+print_output(library='cuml', algorithm='train_test_split',
              stages=['training'], columns=columns, params=params,
              functions=['train_test_split'], times=[time], accuracies=[None],
              accuracy_type=None, data=[X], alg_params=tts_params)

--- a/cuml/train_test_split.py
+++ b/cuml/train_test_split.py
@@ -12,8 +12,8 @@ parser.add_argument('--train-size', type=float, default=0.75,
                     help='Size of training subset')
 parser.add_argument('--test-size', type=float, default=0.25,
                     help='Size of testing subset')
-parser.add_argument('--shuffle', default=False, action='store_true',
-                    help='Perform data shuffle before splitting')
+parser.add_argument('--do-not-shuffle', default=False, action='store_true',
+                    help='Do not perform data shuffle before splitting')
 params = parse_args(parser)
 
 # Load generated data
@@ -22,7 +22,7 @@ X, y, _, _ = load_data(params)
 tts_params = {
     'train_size': params.train_size,
     'test_size': params.test_size,
-    'shuffle': params.shuffle,
+    'shuffle': not params.do_not_shuffle,
     'random_state': params.seed
 }
 

--- a/sklearn/train_test_split.py
+++ b/sklearn/train_test_split.py
@@ -12,8 +12,8 @@ parser.add_argument('--train-size', type=float, default=0.75,
                     help='Size of training subset')
 parser.add_argument('--test-size', type=float, default=0.25,
                     help='Size of testing subset')
-parser.add_argument('--shuffle', default=False, action='store_true',
-                    help='Perform data shuffle before splitting')
+parser.add_argument('--do-not-shuffle', default=False, action='store_true',
+                    help='Do not perform data shuffle before splitting')
 parser.add_argument('--include-y', default=False, action='store_true',
                     help='Include label (Y) in splitting')
 parser.add_argument('--rng', default=None,
@@ -35,7 +35,7 @@ else:
 tts_params = {
     'train_size': params.train_size,
     'test_size': params.test_size,
-    'shuffle': params.shuffle,
+    'shuffle': not params.do_not_shuffle,
     'random_state': params.seed
 }
 

--- a/sklearn/train_test_split.py
+++ b/sklearn/train_test_split.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import argparse
+from bench import measure_function_time, parse_args, load_data, print_output
+from sklearn.model_selection import train_test_split
+
+parser = argparse.ArgumentParser(
+    description='scikit-learn train_test_split benchmark')
+parser.add_argument('--train-size', type=float, default=0.75,
+                    help='Size of training subset')
+parser.add_argument('--test-size', type=float, default=0.25,
+                    help='Size of testing subset')
+parser.add_argument('--shuffle', default=False, action='store_true',
+                    help='Perform data shuffle before splitting')
+parser.add_argument('--exclude-y', default=False, action='store_true',
+                    help='Exclude label (Y) in splitting')
+parser.add_argument('--rng', default=None,
+                    choices=('MT19937', 'SFMT19937', 'MT2203', 'R250', 'WH',
+                             'MCG31', 'MCG59', 'MRG32K3A', 'PHILOX4X32X10',
+                             'NONDETERM', None),
+                    help='Random numbers generator for shuffling '
+                         '(only for IDP scikit-learn)')
+params = parse_args(parser)
+
+# Load generated data
+X, y, _, _ = load_data(params)
+
+if params.exclude_y:
+    data_args = (X, )
+else:
+    data_args = (X, y)
+
+tts_params = {
+    'train_size': params.train_size,
+    'test_size': params.test_size,
+    'shuffle': params.shuffle,
+    'random_state': params.seed
+}
+
+if params.rng is not None:
+    tts_params['rng'] = params.rng
+
+time, _ = measure_function_time(train_test_split, *data_args, **tts_params,
+                                params=params)
+
+columns = ('batch', 'arch', 'prefix', 'function', 'threads', 'dtype', 'size',
+           'time')
+
+print_output(library='sklearn', algorithm='train_test_split',
+             stages=['training'], columns=columns, params=params,
+             functions=['train_test_split'], times=[time], accuracies=[None],
+             accuracy_type=None, data=[X], alg_params=tts_params)


### PR DESCRIPTION
Benchmarks for scikit-learn and cuml implementation of train_test_split function.
Scikit-learn API reference: https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html