### PR TITLE
Add device information in the report json file

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -463,6 +463,7 @@ def gen_basic_dict(library, algorithm, stage, params, data, alg_instance=None,
         'library': library,
         'algorithm': algorithm,
         'stage': stage,
+        'device': params.device,
         'input_data': {
             'data_format': params.data_format,
             'data_order': params.data_order,

--- a/utils.py
+++ b/utils.py
@@ -94,6 +94,11 @@ def get_omp_env():
     }
     return omp_env
 
+def parse_lscpu_lscl_info(command_output):
+    command_output = command_output.split('\n')
+    for i in range(len(command_output)):
+        command_output[i] = command_output[i].split(':')
+    return {line[0].strip(): line[1].strip() for line in command_output}
 
 def get_hw_parameters():
     hw_params = {}
@@ -101,16 +106,10 @@ def get_hw_parameters():
     if 'Linux' in platform.platform():
         # get CPU information
         lscpu_info, _ = read_output_from_command('lscpu')
-        # remove excess spaces in CPU info output
-        while '  ' in lscpu_info:
-            lscpu_info = lscpu_info.replace('  ', ' ')
-        lscpu_info = lscpu_info.split('\n')
-        for i in range(len(lscpu_info)):
-            lscpu_info[i] = lscpu_info[i].split(': ')
-        hw_params.update(
-            {'CPU': {line[0]: line[1] for line in lscpu_info}})
+        hw_params.update({'CPU': parse_lscpu_lscl_info(lscpu_info)})
         if 'CPU MHz' in hw_params['CPU'].keys():
             del hw_params['CPU']['CPU MHz']
+
         # get RAM size
         mem_info, _ = read_output_from_command('free -b')
         mem_info = mem_info.split('\n')[1]
@@ -118,14 +117,22 @@ def get_hw_parameters():
             mem_info = mem_info.replace('  ', ' ')
         mem_info = int(mem_info.split(' ')[1]) / 2 ** 30
         hw_params.update({'RAM size[GB]': mem_info})
-        # get GPU information
+
+        # get Intel GPU information
+        try:
+            lsgpu_info, _ = read_output_from_command('lscl --device-type=gpu --platform-vendor=Intel')
+            hw_params.update({'GPU Intel': parse_lscpu_lscl_info(lsgpu_info)})
+        except (FileNotFoundError, json.JSONDecodeError):
+            pass
+
+        # get Nvidia GPU information
         try:
             gpu_info, _ = read_output_from_command(
                 'nvidia-smi --query-gpu=name,memory.total,driver_version,pstate '
                 '--format=csv,noheader')
             gpu_info = gpu_info.split(', ')
             hw_params.update({
-                'GPU': {
+                'GPU Nvidia': {
                     'Name': gpu_info[0],
                     'Memory size': gpu_info[1],
                     'Performance mode': gpu_info[3]

--- a/utils.py
+++ b/utils.py
@@ -124,14 +124,14 @@ def get_hw_parameters():
         try:
             lsgpu_info, _ = read_output_from_command(
                 'lscl --device-type=gpu --platform-vendor=Intel')
-            platform_num = 0
-            start_idx = lsgpu_info.find('Platform ')
+            device_num = 0
+            start_idx = lsgpu_info.find('Device ')
             while start_idx >= 0:
                 start_idx = lsgpu_info.find(':', start_idx) + 1
-                end_idx = lsgpu_info.find('Platform ', start_idx)
+                end_idx = lsgpu_info.find('Device ', start_idx)
                 platform_info = parse_lscpu_lscl_info(lsgpu_info[start_idx:end_idx])
-                hw_params.update({f'GPU Intel platform {platform_num + 1}': platform_info})
-                platform_num += 1
+                hw_params.update({f'GPU Intel #{device_num + 1}': platform_info})
+                device_num += 1
                 start_idx = end_idx
         except (FileNotFoundError, json.JSONDecodeError):
             pass


### PR DESCRIPTION
- `device` keyword added to the report of each benchmark to recognize which device was used
- Intel GPU hardware information included in the report if such GPU exists on the system

Example of result.json:
hardware section
``` json
"GPU Intel #1": {
            "Type": "GPU",
            "Profile": "FULL_PROFILE",
            "Version": "OpenCL 3.0 NEO",
            "Name": "Intel(R) Iris(TM) Pro Graphics P580 [0x193a]",
            "Vendor": "Intel(R) Corporation",
            "C version": "OpenCL C 3.0",
            "Driver version": "21.13.1943"
 }
```

example of benchmark output:
``` json
{
            "library": "sklearn",
            "algorithm": "kmeans",
            "stage": "training",
            "device": "gpu",
            "input_data": {
                "data_format": "pandas",
                "data_order": "F",
                "data_type": "float64",
                "dataset_name": "synthetic_blobs",
                "rows": 1000000,
                "columns": 50,
                "n_clusters": 10
            },
            "algorithm_parameters": {
                "algorithm": "auto",
                "copy_x": true,
                "init": "random",
                "max_iter": 100,
                "n_clusters": 10,
                "n_init": 1,
                "n_jobs": "deprecated",
                "precompute_distances": "deprecated",
                "random_state": null,
                "tol": 0.0,
                "verbose": 0
            },
            "time[s]": 82.32738574920222,
            "davies_bouldin_score": 4.552364858732523
}
```