### PR TITLE
Fix missing cuML Random Forest parameter

### DIFF
--- a/cuml_bench/df_clsf.py
+++ b/cuml_bench/df_clsf.py
@@ -72,7 +72,7 @@ def fit(X, y):
                                  n_estimators=params.num_trees,
                                  max_depth=params.max_depth,
                                  max_features=params.max_features,
-                                 min_rows_per_node=params.min_samples_split,
+                                 min_samples_split=params.min_samples_split,
                                  max_leaves=params.max_leaf_nodes,
                                  min_impurity_decrease=params.min_impurity_decrease,
                                  bootstrap=params.bootstrap)

--- a/cuml_bench/df_regr.py
+++ b/cuml_bench/df_regr.py
@@ -70,7 +70,7 @@ def fit(X, y):
                                  n_estimators=params.num_trees,
                                  max_depth=params.max_depth,
                                  max_features=params.max_features,
-                                 min_rows_per_node=params.min_samples_split,
+                                 min_samples_split=params.min_samples_split,
                                  max_leaves=params.max_leaf_nodes,
                                  min_impurity_decrease=params.min_impurity_decrease,
                                  bootstrap=params.bootstrap)


### PR DESCRIPTION
`min_rows_per_node` cuML Random Forest parameter was renamed to `min_samples_split`: [API link](https://docs.rapids.ai/api/cuml/stable/api.html#random-forest). It wasn't changed in benchmarks and leads to error while running.