### PR TITLE
Add available devices and dtypes selection to runner.py

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -173,8 +173,8 @@ def parse_args(parser, size=None, loop_types=(),
                         action='store_true',
                         help='Use no intel optimized version. '
                         'Now avalible for scikit-learn benchmarks')
-    parser.add_argument('--device', default='None', type=str,
-                        choices=('host', 'cpu', 'gpu', 'None'),
+    parser.add_argument('--device', default='none', type=str,
+                        choices=('host', 'cpu', 'gpu', 'none'),
                         help='Execution context device')
 
     for data in ['X', 'y']:
@@ -198,15 +198,15 @@ def parse_args(parser, size=None, loop_types=(),
         except ImportError:
             logging.info('Failed to import sklearnex.patch_sklearn.'
                          'Use stock version scikit-learn', file=sys.stderr)
-            params.device = 'None'
+            params.device = 'none'
     else:
-        if params.device != 'None':
+        if params.device != 'none':
             logging.info(
                 'Device context is not supported for stock scikit-learn.'
                 'Please use --no-intel-optimized=False with'
-                f'--device={params.device} parameter. Fallback to --device=None.',
+                f'--device={params.device} parameter. Fallback to --device=none.',
                 file=sys.stderr)
-            params.device = 'None'
+            params.device = 'none'
 
     # disable finiteness check (default)
     if not params.check_finiteness:
@@ -554,7 +554,7 @@ def print_output(library, algorithm, stages, params, functions,
 
 
 def run_with_context(params, function):
-    if params.device != 'None':
+    if params.device != 'none':
         from daal4py.oneapi import sycl_context
         with sycl_context(params.device):
             function()

--- a/configs/skl_xpu_config.json
+++ b/configs/skl_xpu_config.json
@@ -4,7 +4,7 @@
         "data-format": "pandas",
         "data-order": "F",
         "dtype": "float64",
-        "device": ["host", "cpu", "gpu", "None"]
+        "device": ["host", "cpu", "gpu", "none"]
     },
     "cases": [
         {

--- a/runner.py
+++ b/runner.py
@@ -44,9 +44,17 @@ if __name__ == '__main__':
                         default='configs/config_example.json',
                         help='The path to a configuration file or '
                              'a directory that contains configuration files')
+    parser.add_argument('--device', '--devices', default='host cpu gpu None', type=str, nargs='+',
+                        choices=('host', 'cpu', 'gpu', 'None'),
+                        help='Availible execution context devices. '
+                        'This parameter only marks devices as available, '
+                        'make sure to add the device to the config file to run it on a specific device')
     parser.add_argument('--dummy-run', default=False, action='store_true',
                         help='Run configuration parser and datasets generation '
                              'without benchmarks running')
+    parser.add_argument('--dtype', '--dtypes', type=str, default="float32 float64", nargs='+',
+                        choices=("float32", "float64"),
+                        help='Available Data types')
     parser.add_argument('--no-intel-optimized', default=False, action='store_true',
                         help='Use Scikit-learn without Intel optimizations')
     parser.add_argument('--output-file', default='results.json',
@@ -93,6 +101,27 @@ if __name__ == '__main__':
         for params_set in config['cases']:
             params = common_params.copy()
             params.update(params_set.copy())
+
+            device = []
+            if 'device' not in params:
+                if 'sklearn' in params['lib']:
+                    logging.info('The device parameter value is not defined in config, None is used')
+                device = ['None']
+            elif not isinstance(params['device'] , list):
+                device = [params['device']]
+            else:
+                device = params['device']
+            params["device"] = [dv for dv in device if dv in args.device]
+
+            dtype = []
+            if 'dtype' not in params:
+                dtype = ['float64']
+            elif not isinstance(params['dtype'] , list):
+                dtype = [params['dtype']]
+            else:
+                dtype = params['dtype']
+            params['dtype'] = [dt for dt in dtype if dt in args.dtype]
+
             algorithm = params['algorithm']
             libs = params['lib']
             if not isinstance(libs, list):

--- a/runner.py
+++ b/runner.py
@@ -55,7 +55,9 @@ if __name__ == '__main__':
                              'without benchmarks running')
     parser.add_argument('--dtype', '--dtypes', type=str, default="float32 float64", nargs='+',
                         choices=("float32", "float64"),
-                        help='Available Data types')
+                        help='Available floating point data types'
+                        'This parameter only marks dtype as available, '
+                        'make sure to add the dtype parameter to the config file ')
     parser.add_argument('--no-intel-optimized', default=False, action='store_true',
                         help='Use Scikit-learn without Intel optimizations')
     parser.add_argument('--output-file', default='results.json',

--- a/runner.py
+++ b/runner.py
@@ -44,8 +44,8 @@ if __name__ == '__main__':
                         default='configs/config_example.json',
                         help='The path to a configuration file or '
                              'a directory that contains configuration files')
-    parser.add_argument('--device', '--devices', default='host cpu gpu None', type=str, nargs='+',
-                        choices=('host', 'cpu', 'gpu', 'None'),
+    parser.add_argument('--device', '--devices', default='host cpu gpu none', type=str, nargs='+',
+                        choices=('host', 'cpu', 'gpu', 'none'),
                         help='Availible execution context devices. '
                         'This parameter only marks devices as available, '
                         'make sure to add the device to the config file '
@@ -107,8 +107,8 @@ if __name__ == '__main__':
             if 'device' not in params:
                 if 'sklearn' in params['lib']:
                     logging.info('The device parameter value is not defined in config, '
-                                 'None is used')
-                device = ['None']
+                                 'none is used')
+                device = ['none']
             elif not isinstance(params['device'], list):
                 device = [params['device']]
             else:

--- a/runner.py
+++ b/runner.py
@@ -48,7 +48,8 @@ if __name__ == '__main__':
                         choices=('host', 'cpu', 'gpu', 'None'),
                         help='Availible execution context devices. '
                         'This parameter only marks devices as available, '
-                        'make sure to add the device to the config file to run it on a specific device')
+                        'make sure to add the device to the config file '
+                        'to run it on a specific device')
     parser.add_argument('--dummy-run', default=False, action='store_true',
                         help='Run configuration parser and datasets generation '
                              'without benchmarks running')
@@ -105,9 +106,10 @@ if __name__ == '__main__':
             device = []
             if 'device' not in params:
                 if 'sklearn' in params['lib']:
-                    logging.info('The device parameter value is not defined in config, None is used')
+                    logging.info('The device parameter value is not defined in config, '
+                                 'None is used')
                 device = ['None']
-            elif not isinstance(params['device'] , list):
+            elif not isinstance(params['device'], list):
                 device = [params['device']]
             else:
                 device = params['device']
@@ -116,7 +118,7 @@ if __name__ == '__main__':
             dtype = []
             if 'dtype' not in params:
                 dtype = ['float64']
-            elif not isinstance(params['dtype'] , list):
+            elif not isinstance(params['dtype'], list):
                 dtype = [params['dtype']]
             else:
                 dtype = params['dtype']


### PR DESCRIPTION
Add parameters to runner.py that define devices and data types available to run
Unselected devices and data types will be ignored in configs

for example if config contains
`device: ["host", "gpu",  "cpu"]`
and you run
`python runner.py --devices cpu gpu`
cpu and gpu cases will be launched,
but if config contains:
`device: ["host", "gpu"]`
and you run 
`python runner.py --devices cpu gpu`
only  gpu case will be launched 

default values ​​do not limit the available devices and data types
