### PR TITLE
Report config selector

### DIFF
--- a/report_generator/xpu_report_gen_config.json
+++ b/report_generator/xpu_report_gen_config.json
@@ -1,0 +1,31 @@
+{
+    "header": [
+        "algorithm",
+        "stage",
+        "device",
+        "input_data:data_order",
+        "input_data:data_type",
+        "input_data:dataset_name",
+        "input_data:classes",
+        "algorithm_parameters:tol",
+        "algorithm_parameters:max_iter",
+        "algorithm_parameters:solver",
+        "algorithm_parameters:C",
+        "algorithm_parameters:kernel",
+        "algorithm_parameters:nu",
+        "algorithm_parameters:eps",
+        "algorithm_parameters:n_neighbors",
+        "algorithm_parameters:n_estimators",
+        "algorithm_parameters:n_clusters",
+        "algorithm_parameters:min_samples",
+        "algorithm_parameters:fit_intercept",
+        "algorithm_parameters:max_depth",
+        "algorithm_parameters:max_features"
+    ],
+    "comparison_method": {
+        "default": "2 / 1"
+    },
+    "aggregation_metrics": [
+        "geomean"
+    ]
+}

--- a/runner.py
+++ b/runner.py
@@ -66,9 +66,10 @@ if __name__ == '__main__':
     parser.add_argument('--verbose', default='INFO', type=str,
                         choices=("ERROR", "WARNING", "INFO", "DEBUG"),
                         help='Print additional information during benchmarks running')
-    parser.add_argument('--report', default=False, action='store_true',
-                        help='Create an Excel report based on benchmarks results. '
-                             'Need "openpyxl" library')
+    parser.add_argument('--report-config', default=None, metavar='ConfigPath', type=str,
+                        help='config file for the reporter, if None the reporter will not be started'
+                        'Create an Excel report based on benchmarks results. '
+                        'Need "openpyxl" library')
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -263,12 +264,13 @@ if __name__ == '__main__':
     json.dump(json_result, args.output_file, indent=4)
     name_result_file = args.output_file.name
     args.output_file.close()
+    basename_result_file = os.path.splitext(name_result_file)[0]
 
     if args.report:
         command = 'python report_generator/report_generator.py ' \
             + f'--result-files {name_result_file} '              \
-            + f'--report-file {name_result_file}.xlsx '          \
-            + '--generation-config report_generator/default_report_gen_config.json'
+            + f'--report-file {basename_result_file}.xlsx '      \
+            + '--generation-config ' + args.report
         logging.info(command)
         stdout, stderr = utils.read_output_from_command(command)
         if stderr != '':

--- a/runner.py
+++ b/runner.py
@@ -68,9 +68,10 @@ if __name__ == '__main__':
                         help='Print additional information during benchmarks running')
     parser.add_argument('--report', nargs='?', default=None, metavar='ConfigPath', type=str,
                         const='report_generator/default_report_gen_config.json',
-                        help='config file for the reporter, '
-                        'if None the reporter will not be started '
-                        'Create an Excel report based on benchmarks results. '
+                        help='Create an Excel report based on benchmarks results. '
+                        'If the parameter is not set, the reporter will not be launched. '
+                        'If the parameter is set and the config is not specified, '
+                        'the default config will be used. '
                         'Need "openpyxl" library')
     args = parser.parse_args()
 

--- a/runner.py
+++ b/runner.py
@@ -66,9 +66,10 @@ if __name__ == '__main__':
     parser.add_argument('--verbose', default='INFO', type=str,
                         choices=("ERROR", "WARNING", "INFO", "DEBUG"),
                         help='Print additional information during benchmarks running')
-    parser.add_argument('--report', nargs='?', const='report_generator/default_report_gen_config.json',
-                        default=None, metavar='ConfigPath', type=str,
-                        help='config file for the reporter, if None the reporter will not be started '
+    parser.add_argument('--report', nargs='?', default=None, metavar='ConfigPath', type=str,
+                        const='report_generator/default_report_gen_config.json',
+                        help='config file for the reporter, '
+                        'if None the reporter will not be started '
                         'Create an Excel report based on benchmarks results. '
                         'Need "openpyxl" library')
     args = parser.parse_args()

--- a/runner.py
+++ b/runner.py
@@ -66,7 +66,8 @@ if __name__ == '__main__':
     parser.add_argument('--verbose', default='INFO', type=str,
                         choices=("ERROR", "WARNING", "INFO", "DEBUG"),
                         help='Print additional information during benchmarks running')
-    parser.add_argument('--report-config', default=None, metavar='ConfigPath', type=str,
+    parser.add_argument('--report', nargs='?', const='report_generator/default_report_gen_config.json',
+                        default=None, metavar='ConfigPath', type=str,
                         help='config file for the reporter, if None the reporter will not be started '
                         'Create an Excel report based on benchmarks results. '
                         'Need "openpyxl" library')

--- a/runner.py
+++ b/runner.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
                         choices=("ERROR", "WARNING", "INFO", "DEBUG"),
                         help='Print additional information during benchmarks running')
     parser.add_argument('--report-config', default=None, metavar='ConfigPath', type=str,
-                        help='config file for the reporter, if None the reporter will not be started'
+                        help='config file for the reporter, if None the reporter will not be started '
                         'Create an Excel report based on benchmarks results. '
                         'Need "openpyxl" library')
     args = parser.parse_args()

--- a/runner.py
+++ b/runner.py
@@ -266,12 +266,11 @@ if __name__ == '__main__':
     json.dump(json_result, args.output_file, indent=4)
     name_result_file = args.output_file.name
     args.output_file.close()
-    basename_result_file = os.path.splitext(name_result_file)[0]
 
     if args.report:
         command = 'python report_generator/report_generator.py ' \
             + f'--result-files {name_result_file} '              \
-            + f'--report-file {basename_result_file}.xlsx '      \
+            + f'--report-file {name_result_file}.xlsx '          \
             + '--generation-config ' + args.report
         logging.info(command)
         stdout, stderr = utils.read_output_from_command(command)


### PR DESCRIPTION
Add option for report config selection
If report flag is not set, report generator will not be launched
If no config specified default config will be used

`python runner.py --report`
(launch report with default config)
`python runner.py --report report_generator/myconf.json`
(launch report with  custom config)

Added more detailed config for new benchmark cases