### PR TITLE
Adding check for nan values

### DIFF
--- a/modelbuilders_bench/lgbm_mb.py
+++ b/modelbuilders_bench/lgbm_mb.py
@@ -16,6 +16,8 @@
 
 import argparse
 import os
+import logging
+import sys
 
 import bench
 import daal4py
@@ -83,6 +85,10 @@ lgbm_params = {
     'objective': params.objective,
     'seed': params.seed
 }
+
+if np.isnan(X_test.values).any():
+    logging.warning('Nan values aren not supported in model builder yet')
+    sys.exit(1)
 
 if params.threads != -1:
     lgbm_params.update({'nthread': params.threads})

--- a/modelbuilders_bench/xgb_mb.py
+++ b/modelbuilders_bench/xgb_mb.py
@@ -15,6 +15,8 @@
 # ===============================================================================
 
 import argparse
+import logging
+import sys
 
 import bench
 import daal4py
@@ -114,6 +116,10 @@ xgb_params = {
     'enable_experimental_json_serialization':
         params.enable_experimental_json_serialization
 }
+
+if np.isnan(X_test.values).any():
+    logging.warning('Nan values aren not supported in model builder yet')
+    sys.exit(1)
 
 if params.threads != -1:
     xgb_params.update({'nthread': params.threads})


### PR DESCRIPTION
Nan values are not supported for model builders yet. However, no internal checks are not implemented. Checks in the benchmarks looks like a possible intermediate solution.