### PR TITLE
np.float is depricated in numpy 1.24

### DIFF
--- a/modelbuilders_bench/mb_utils.py
+++ b/modelbuilders_bench/mb_utils.py
@@ -23,7 +23,7 @@ def get_accuracy(true_labels, prediction):
     errors = 0
     for i, true_label in enumerate(true_labels):
         pred_label = 0
-        if isinstance(prediction[i], (float, np.single)):
+        if isinstance(prediction[i], (np.float32, np.float64)):
             pred_label = prediction[i] > 0.5
         elif prediction[i].shape[0] == 1:
             pred_label = prediction[i][0]

--- a/modelbuilders_bench/mb_utils.py
+++ b/modelbuilders_bench/mb_utils.py
@@ -23,7 +23,7 @@ def get_accuracy(true_labels, prediction):
     errors = 0
     for i, true_label in enumerate(true_labels):
         pred_label = 0
-        if isinstance(prediction[i], (float, np.single, np.float)):
+        if isinstance(prediction[i], (float, np.single)):
             pred_label = prediction[i] > 0.5
         elif prediction[i].shape[0] == 1:
             pred_label = prediction[i][0]


### PR DESCRIPTION
np.float is [depricated](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations) in numpy 1.24