### PR TITLE
Fix issue #75: Benchmarks silently execute stock version if scikit-learn-intelex is not installed

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -187,6 +187,8 @@ def parse_args(parser, size=None, loop_types=(),
                         choices=('host', 'cpu', 'gpu', 'none'),
                         help='Execution context device')
 
+    logging.basicConfig(stream=sys.stderr, format='%(levelname)s: %(message)s', level=logging.INFO)
+
     for data in ['X', 'y']:
         for stage in ['train', 'test']:
             parser.add_argument(f'--file-{data}-{stage}',
@@ -207,15 +209,14 @@ def parse_args(parser, size=None, loop_types=(),
             patch_sklearn()
         except ImportError:
             logging.info('Failed to import sklearnex.patch_sklearn.'
-                         'Use stock version scikit-learn', file=sys.stderr)
+                         'Use stock version scikit-learn')
             params.device = 'none'
     else:
         if params.device != 'none':
             logging.info(
                 'Device context is not supported for stock scikit-learn.'
                 'Please use --no-intel-optimized=False with'
-                f'--device={params.device} parameter. Fallback to --device=none.',
-                file=sys.stderr)
+                f'--device={params.device} parameter. Fallback to --device=none.')
             params.device = 'none'
 
     # disable finiteness check (default)

--- a/runner.py
+++ b/runner.py
@@ -285,7 +285,7 @@ if __name__ == '__main__':
                         logging.info(command)
                         if not args.dummy_run:
                             case = f'{lib},{algorithm} ' + case
-                            stdout, stderr = utils.read_output_from_command(
+                            stdout, stderr, ret_code = utils.read_output_from_command(
                                 command, env=os.environ.copy())
                             stdout, extra_stdout = utils.filter_stdout(stdout)
                             stderr = utils.filter_stderr(stderr)
@@ -303,11 +303,13 @@ if __name__ == '__main__':
                                 stderr += f'CASE {case} JSON DECODING ERROR:\n' \
                                     + f'{decoding_exception}\n{stdout}\n'
 
-                            if stderr != '':
-                                if 'daal4py' not in stderr:
-                                    is_successful = False
-                                    logging.warning(
-                                        'Error in benchmark: \n' + stderr)
+                            if ret_code == 1:
+                                is_successful = False
+                                logging.warning('Error in benchmark: \n' +
+                                                stderr)
+                            else:
+                                # print info/warnings in benchmark
+                                print(stderr, end='\n')
 
     json.dump(json_result, args.output_file, indent=4)
     name_result_file = args.output_file.name
@@ -319,8 +321,8 @@ if __name__ == '__main__':
             + f'--report-file {name_result_file}.xlsx '          \
             + '--generation-config ' + args.report
         logging.info(command)
-        stdout, stderr = utils.read_output_from_command(command)
-        if stderr != '':
+        stdout, stderr, ret_code = utils.read_output_from_command(command)
+        if ret_code == 1:
             logging.warning('Error in report generator: \n' + stderr)
             is_successful = False
 

--- a/runner.py
+++ b/runner.py
@@ -288,7 +288,7 @@ if __name__ == '__main__':
                             stdout, stderr, ret_code = utils.read_output_from_command(
                                 command, env=os.environ.copy())
                             stdout, extra_stdout = utils.filter_stdout(stdout)
-                            stderr = utils.filter_stderr(stderr)
+                            stderr = utils.filter_stderr(stderr) + '\n'
 
                             print(stdout, end='\n')
 

--- a/utils.py
+++ b/utils.py
@@ -85,7 +85,7 @@ def find_the_dataset(name: str, folder: str, files: Iterable[str]):
 
 
 def read_output_from_command(command: str,
-                             env: Dict[str, str] = os.environ.copy()) -> Tuple[str, str]:
+                             env: Dict[str, str] = os.environ.copy()) -> Tuple[str, str, int]:
     if "PYTHONPATH" in env:
         env["PYTHONPATH"] += ":" + os.path.dirname(os.path.abspath(__file__))
     else:


### PR DESCRIPTION
Fix log not displayed in bench.py
Before this fix the log isn't displayed in bench.py, because bench.py is
running via subprocess, so the log config set in runner.py has no effect in
bench.py, and the log config in bench.py follows the default strategy
(log_level=WARNING, stream=stderr), so when scikit-learn-intelex is not
installed, the info log can't be displayed, furthermore, all other info logs
in bench.py can't be displayed either.

This fix does the following change:
1. Set a log config in bench.py (log_level=INFO, stream=stderr).
2. Add return_code in the return value of utils.read_output_from_command() to identify if there is any error in subprocess.
3. In runner.py, if no error occured, the log from subprocess in stderr will be printed, otherwise is_success will be set to False and the error message will be displayed through a warning log.

Fixes https://github.com/IntelPython/scikit-learn_bench/issues/75

Co-authored-by: Wu, Zihan <zihan.wu@intel.com>
Signed-off-by: Deng, Lulin <lulin.deng@intel.com>
Signed-off-by: Zhou, Shuangpeng <shuangpeng.zhou@intel.com>
Signed-off-by: Xu, Yanyue <yanyue.xu@intel.com>