### PR TITLE
More specific write access message

### DIFF
--- a/datasets/make_datasets.py
+++ b/datasets/make_datasets.py
@@ -34,7 +34,7 @@ def try_gen_dataset(args, folder):
         else:
             raise ValueError(f'{args.type} is unknown dataset type')
         return True
-    except PermissionError as ex:
+    except PermissionError:
         logging.warning(f"Write access to {folder} denied. Writing to local path instead.")
         return False
     except BaseException as ex:

--- a/datasets/make_datasets.py
+++ b/datasets/make_datasets.py
@@ -34,6 +34,9 @@ def try_gen_dataset(args, folder):
         else:
             raise ValueError(f'{args.type} is unknown dataset type')
         return True
+    except PermissionError as ex:
+        logging.warning(f"Write access to {folder} denied. Writing to local path instead.")
+        return False
     except BaseException as ex:
         logging.warning(f"Internal error generating dataset:\n{ex}")
         return False


### PR DESCRIPTION
Associated with task: Fix sklearnex_bench errors if DATASETSROOT is not writeable

- Functionally, the code should already be working as intended - a warning is raised because the path is not writeable, therefore it writes to local path instead. The existing exception is broader so it makes it seem like a problem. Solution is to add a more specific exception for the case where the error is permission denied/not writeable and raise a more specific message. In both cases it's a warning and functionally the same.