### PR TITLE
Update dependency numpy

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,4 +1,4 @@
-numpy >= 1.21.6, < 2.0* ; python_version >= "3.10"
+numpy >= 1.19.5, < 2.0* ; python_version >= '3.9'
 scikit-learn==1.2.0
 pandas==1.5.2
 openpyxl

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,3 +1,4 @@
+numpy >= 1.21.6, < 2.0* ; python_version >= "3.10"
 scikit-learn==1.2.0
 pandas==1.5.2
 openpyxl


### PR DESCRIPTION
# Description
Update numpy dependency version.
Currently avoiding using numpy 2.0 as a workaround. The problem should be fixed on the sklearnex side.

Numpy 2.0 in env causes:
```
   File "/sources/runner.py", line 25, in <module>
     import utils
   File "/sources/utils.py", line 25, in <module>
     from datasets.make_datasets import try_gen_dataset
   File "/sources/datasets/make_datasets.py", line 21, in <module>
     from sklearn.datasets import make_classification, make_regression, make_blobs
   File "/env/lib/python3.10/site-packages/sklearn/__init__.py", line 82, in <module>
     from .base import clone
   File "/env/lib/python3.10/site-packages/sklearn/base.py", line 17, in <module>
     from .utils import _IS_32BIT
   File "/env/lib/python3.10/site-packages/sklearn/utils/__init__.py", line 19, in <module>
     from .murmurhash import murmurhash3_32
   File "sklearn/utils/murmurhash.pyx", line 1, in init sklearn.utils.murmurhash
 ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```