### PR TITLE
update n_init for kmeans

### DIFF
--- a/configs/regular/kmeans.json
+++ b/configs/regular/kmeans.json
@@ -21,6 +21,11 @@
         "sklearn kmeans parameters": {
             "algorithm": { "estimator_params": { "init": "k-means++", "algorithm": "lloyd" } }
         },
+        "cuml kmeans parameters": {
+            "algorithm": {
+                "estimator_params": { "init": "scalable-k-means++" }
+            }
+        },
         "kmeans datasets": [
             {
                 "data": [
@@ -68,6 +73,14 @@
                 "sklearn-ex[preview] implementations",
                 "common kmeans parameters",
                 "sklearn kmeans parameters",
+                "kmeans datasets"
+            ]
+        },
+        "cuml kmeans": {
+            "SETS": [
+                "cuml implementation",
+                "common kmeans parameters",
+                "cuml kmeans parameters",
                 "kmeans datasets"
             ]
         }

--- a/configs/regular/kmeans.json
+++ b/configs/regular/kmeans.json
@@ -15,7 +15,7 @@
             },
             "data": {
                 "dtype": ["float32", "float64"],
-                "preprocessing_kwargs": { "normalize": false }
+                "preprocessing_kwargs": { "normalize": true }
             }
         },
         "sklearn kmeans parameters": {

--- a/configs/regular/kmeans.json
+++ b/configs/regular/kmeans.json
@@ -6,7 +6,7 @@
                 "estimator": "KMeans",
                 "estimator_params": {
                     "n_clusters": "[SPECIAL_VALUE]auto",
-                    "n_init": 10,
+                    "n_init": 1,
                     "max_iter": 30,
                     "tol": 1e-3,
                     "random_state": 42
@@ -15,16 +15,11 @@
             },
             "data": {
                 "dtype": ["float32", "float64"],
-                "preprocessing_kwargs": { "normalize": true }
+                "preprocessing_kwargs": { "normalize": false }
             }
         },
         "sklearn kmeans parameters": {
             "algorithm": { "estimator_params": { "init": "k-means++", "algorithm": "lloyd" } }
-        },
-        "cuml kmeans parameters": {
-            "algorithm": {
-                "estimator_params": { "init": "scalable-k-means++" }
-            }
         },
         "kmeans datasets": [
             {
@@ -73,14 +68,6 @@
                 "sklearn-ex[preview] implementations",
                 "common kmeans parameters",
                 "sklearn kmeans parameters",
-                "kmeans datasets"
-            ]
-        },
-        "cuml kmeans": {
-            "SETS": [
-                "cuml implementation",
-                "common kmeans parameters",
-                "cuml kmeans parameters",
                 "kmeans datasets"
             ]
         }


### PR DESCRIPTION
 - For kmeans++, the default n_init=1 https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/cluster/_kmeans.py#L346. Probably makes sense to benchmark the default behavior.