### PR TITLE
Update solver in PCA config

### DIFF
--- a/configs/regular/pca.json
+++ b/configs/regular/pca.json
@@ -8,7 +8,7 @@
                     "n_components": 3,
                     "copy": true,
                     "whiten": false,
-                    "svd_solver": "full",
+                    "svd_solver": "covariance_eigh",
                     "tol": 0.0,
                     "iterated_power": 15,
                     "random_state": 42

--- a/envs/conda-env-sklearn.yml
+++ b/envs/conda-env-sklearn.yml
@@ -10,7 +10,7 @@ dependencies:
   - modin-all
   - scikit-learn-intelex
   # sklbench dependencies
-  - scikit-learn<1.5
+  - scikit-learn
   - pandas
   - tabulate
   - fastparquet

--- a/envs/requirements-sklearn.txt
+++ b/envs/requirements-sklearn.txt
@@ -8,7 +8,7 @@ scikit-learn-intelex
 dpctl
 dpnp
 # sklbench dependencies
-scikit-learn<1.5
+scikit-learn
 pandas
 tabulate
 fastparquet


### PR DESCRIPTION
Update `svd_solver=covariance_eigh` in PCA config to reflect [sklearn 1.5](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html#pca) and related [sklearnex patching](https://github.com/intel/scikit-learn-intelex/commit/ba8206df0260c19cb2759702b318d5067c56c888#diff-9624711e0882a1b18ec37e33bbe526d4889c4d2f699a48cdf54f8a9c343cd0e3R230) changes.

Remove `sklearn<1.5` limitation.