### PR TITLE
FIX: Don't error out when JSON doesn't end with empty line

### DIFF
--- a/sklbench/utils/common.py
+++ b/sklbench/utils/common.py
@@ -124,7 +124,7 @@ def flatten_list(input_list: List, ensure_type_homogeneity: bool = False) -> Lis
 
 
 def get_module_members(
-    module_names_chain: Union[List, str]
+    module_names_chain: Union[List, str],
 ) -> Tuple[ModuleContentMap, ModuleContentMap]:
     def get_module_name(module_names_chain: List[str]) -> str:
         name = module_names_chain[0]

--- a/sklbench/utils/common.py
+++ b/sklbench/utils/common.py
@@ -66,7 +66,7 @@ def read_output_from_command(command: str) -> Tuple[int, str, str]:
         stderr=sp.PIPE,
         encoding="utf-8",
     )
-    return res.returncode, res.stdout[:-1], res.stderr[:-1]
+    return res.returncode, res.stdout.strip(), res.stderr.strip()
 
 
 def hash_from_json_repr(x: JsonTypesUnion, hash_limit: int = 5) -> str:

--- a/sklbench/utils/common.py
+++ b/sklbench/utils/common.py
@@ -66,7 +66,11 @@ def read_output_from_command(command: str) -> Tuple[int, str, str]:
         stderr=sp.PIPE,
         encoding="utf-8",
     )
-    return res.returncode, res.stdout.strip(), res.stderr.strip()
+    return (
+        res.returncode,
+        res.stdout.strip(),
+        res.stderr.strip(),
+    )
 
 
 def hash_from_json_repr(x: JsonTypesUnion, hash_limit: int = 5) -> str:


### PR DESCRIPTION
## Description

This PR fixes an issue in which the logic here would assume that JSON outputs from `conda list` would always have an empty line at the end, which is not necessarily the case depending on versions and shell nuances.

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
