### PR TITLE
Fixes for  Unresolved comment '# TODO: remove placeholding zeroed y' and Unresolved comment '# TODO: add float values'. 

### DIFF
--- a/sklbench/datasets/loaders.py
+++ b/sklbench/datasets/loaders.py
@@ -802,7 +802,8 @@ def load_ann_dataset_template(url, raw_data_cache):
     }
     del x_train, x_test
     # TODO: remove placeholding zeroed y
-    y = np.zeros((x.shape[0],))
+    #y = np.zeros((x.shape[0],))
+    y = np.zeros(x.shape[0])
     return {"x": x, "y": y}, data_desc
 
 

--- a/sklbench/utils/special_params.py
+++ b/sklbench/utils/special_params.py
@@ -36,6 +36,10 @@ SP_VALUE_STR = "[SPECIAL_VALUE]"
 def is_special_value(value) -> bool:
     return isinstance(value, str) and value.startswith(SP_VALUE_STR)
 
+def float_range(start,stop,step):
+    while start < stop:
+        yield start
+        start += step
 
 def explain_range(range_str: str) -> List:
     def check_range_values_size(range_values: List[int], size: int):
@@ -47,13 +51,15 @@ def explain_range(range_str: str) -> List:
     range_values = range_str.replace("[RANGE]", "").split(":")
     # TODO: add float values
     range_type = range_values[0]
-    range_values = list(map(int, range_values[1:]))
+    #range_values = list(map(int, range_values[1:]))
+    range_values = list(map(float, range_values[1:]))
     # - add:start{int}:end{int}:step{int} - Arithmetic progression
     #   Sequence: start + step * i <= end
     if range_type == "add":
         check_range_values_size(range_values, 3)
         start, end, step = range_values
-        return list(range(start, end + step, step))
+        #return list(range(start, end + step, step))
+        return list(float_range(start, end + step, step))
     # - mul:current{int}:end{int}:step{int} - Geometric progression
     #   Sequence: current * step <= end
     elif range_type == "mul":
@@ -71,7 +77,8 @@ def explain_range(range_str: str) -> List:
             range_values.append(1)
         check_range_values_size(range_values, 4)
         base, start, end, step = range_values
-        return [base**i for i in range(start, end + step, step)]
+        #return [base**i for i in range(start, end + step, step)]
+        return [base**i for i in float_range(start, end + step, step)]
     else:
         raise ValueError(f'Unknown "{range_type}" range type')
 


### PR DESCRIPTION
Fixes for  Unresolved comment '# TODO: remove placeholding zeroed y' in sklbench\datasets\loaders.py:804 and Unresolved comment '# TODO: add float values'.  in sklbench\utils\special_params.py:48

## Description
Fixes in Unresolved comment '# TODO: remove placeholding zeroed y'. lines of code = 1 in sklbench\datasets\loaders.py:804

Originally it was like    y = np.zeros((x.shape[0],))
Changed it to y = np.zeros(x.shape[0])
![image](https://github.com/user-attachments/assets/b62964f1-dffa-4a8a-a8a6-1784b556191b)

Fixes in  Unresolved comment '# TODO: add float values'. lines of code = 1 in Found in [sklbench\utils\special_params.py:48]
I added a function in special_params.py called def float_range(start,stop,step) to accept float values
I tested it in Python:
>>> import sklbench.utils.special_params as spl
>>> spl.explain_range('[RANGE]add:1:5:1')
[1.0, 2.0, 3.0, 4.0, 5.0]
>>> spl.explain_range('[RANGE]add:1.1:5.1:.2')
[1.1, 1.3, 1.5, 1.7, 1.9, 2.1, 2.3000000000000003, 2.5000000000000004, 2.7000000000000006, 2.900000000000001, 3.100000000000001, 3.300000000000001, 3.5000000000000013, 3.7000000000000015, 3.9000000000000017, 4.100000000000001, 4.300000000000002, 4.500000000000002, 4.700000000000002, 4.900000000000002, 5.100000000000002]
>>>spl.explain_range('[RANGE]mul:1.1:5.1:.2')
However for the geometric progression, make sure the step value is greater than 1 as the result gets progressively smaller and will never converge. We can do a comparison for step size to be greater than 1 (currently not implemented)
>>> spl.explain_range('[RANGE]mul:1.1:5.1:2')
[1.1, 2.2, 4.4]
>>> spl.explain_range('[RANGE]pow:1.1:5.1:2')
[]
>>> spl.explain_range('[RANGE]pow:1.1:10:2')
[]
>>> spl.explain_range('[RANGE]pow:0.2:1.1:5.1:2')
[0.1702679845041569, 0.006810719380166277, 0.00027242877520665133]
>>>



---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [X ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.
