### PR TITLE
Fix comparison for `indifferent` metric type in report

### DIFF
--- a/sklbench/report/implementation.py
+++ b/sklbench/report/implementation.py
@@ -193,8 +193,8 @@ def compare_df(input_df, diff_columns, diffs_selection, compared_columns=METRIC_
                             df_ith[column] / df_jth[column]
                         )
                     elif column in METRICS["indifferent"]:
-                        df[f"{comparison_name}\n{column} is equal"] = (
-                            df_ith[column] == df_jth[column]
+                        df[f"{comparison_name}\n{column} is equal"] = df_ith[column].eq(
+                            df_jth[column]
                         )
     df = df.reset_index()
     # move to multi-index


### PR DESCRIPTION
## Description

Usage of `==` operator for `indifferent` metric type led to errors due to unequal indices of compared data frames in some cases. pd.DataFrame's method `eq` handles these cases and assigns values correctly.

---


**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
