### PR TITLE
Avoid patch warning when spmd estimator is used

### DIFF
--- a/sklbench/benchmarks/sklearn_estimator.py
+++ b/sklbench/benchmarks/sklearn_estimator.py
@@ -395,6 +395,7 @@ def measure_sklearn_estimator(
             estimator_class.__module__.startswith("daal4py")
             or estimator_class.__module__.startswith("sklearnex")
         )
+        and "spmd" not in estimator_class.__module__
     )
     sklearnex_logging_stream = get_sklearnex_logging_stream()
 


### PR DESCRIPTION
## Description

This prevents sklbench from raising unpatched estimator warning for spmd algos. Primarily relevant to large-scale branch as these warnings are raised on large_scale configs, but relevant to maim branch as well.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.
