### PR TITLE
Add LogisticRegressionCV to regular config

### DIFF
--- a/configs/regular/logreg_cv.json
+++ b/configs/regular/logreg_cv.json
@@ -1,6 +1,6 @@
 {
     "PARAMETERS_SETS": {
-        "common logreg_cv parameters": {
+        "sklearn logreg_cv parameters": {
             "algorithm": {
                 "estimator": "LogisticRegressionCV",
                 "estimator_methods": { "inference": "predict" },
@@ -31,5 +31,14 @@
                 }
             }
         ]
+    },
+    "TEMPLATES": {
+        "sklearn logreg_cv": {
+            "SETS": [
+                "sklearn-ex[cpu] implementations",
+                "sklearn logreg_cv parameters",
+                "logreg_cv datasets"
+            ]
+        }
     }
 }

--- a/configs/regular/logreg_cv.json
+++ b/configs/regular/logreg_cv.json
@@ -1,0 +1,35 @@
+{
+    "PARAMETERS_SETS": {
+        "common logreg_cv parameters": {
+            "algorithm": {
+                "estimator": "LogisticRegressionCV",
+                "estimator_methods": { "inference": "predict" },
+                "estimator_params": {
+                    "Cs": 10,
+                    "l1_ratios": [0.0],
+                    "solver": "newton-cg",
+                    "random_state": 123
+                }
+            }
+        },
+        "logreg_cv datasets": [
+            {
+                "data": {
+                    "source": "make_classification",
+                    "generation_kwargs": [
+                        {
+                            "n_samples": 250000,
+                            "n_features": 1000,
+                            "n_informative": 800,
+                            "n_classes": [2]
+                        }
+                    ],
+                    "split_kwargs": {
+                        "train_size": 0.05,
+                        "test_size": 0.95
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/configs/regular/logreg_cv.json
+++ b/configs/regular/logreg_cv.json
@@ -9,7 +9,6 @@
                 "estimator_methods": { "inference": "predict" },
                 "estimator_params": {
                     "Cs": 10,
-                    "l1_ratios": [0.0],
                     "solver": "newton-cg",
                     "random_state": 123
                 }

--- a/configs/regular/logreg_cv.json
+++ b/configs/regular/logreg_cv.json
@@ -35,7 +35,7 @@
     "TEMPLATES": {
         "sklearn logreg_cv": {
             "SETS": [
-                "sklearn-ex[cpu] implementations",
+                "sklearn-ex[cpu,gpu] implementations",
                 "sklearn logreg_cv parameters",
                 "logreg_cv datasets"
             ]

--- a/configs/regular/logreg_cv.json
+++ b/configs/regular/logreg_cv.json
@@ -9,7 +9,8 @@
                 "estimator_methods": { "inference": "predict" },
                 "estimator_params": {
                     "Cs": 10,
-                    "solver": "newton-cg",
+                    "solver": "lbfgs",
+                    "max_iter": 1000,
                     "random_state": 123
                 }
             }
@@ -20,7 +21,7 @@
                     "source": "make_classification",
                     "generation_kwargs": [
                         {
-                            "n_samples": 250000,
+                            "n_samples": 100000,
                             "n_features": 1000,
                             "n_informative": 800,
                             "n_classes": [2]

--- a/configs/regular/logreg_cv.json
+++ b/configs/regular/logreg_cv.json
@@ -1,8 +1,11 @@
 {
+    "INCLUDE": ["../common/sklearn.json"],
     "PARAMETERS_SETS": {
         "sklearn logreg_cv parameters": {
             "algorithm": {
                 "estimator": "LogisticRegressionCV",
+                "library": ["sklearn", "sklearnex"],
+                "device": "cpu",
                 "estimator_methods": { "inference": "predict" },
                 "estimator_params": {
                     "Cs": 10,

--- a/envs/conda-env-sklearn.yml
+++ b/envs/conda-env-sklearn.yml
@@ -10,7 +10,7 @@ dependencies:
   - modin-all
   - scikit-learn-intelex
   # sklbench dependencies
-  - scikit-learn
+  - scikit-learn>=1.8
   - pandas
   - tabulate
   - fastparquet

--- a/envs/requirements-sklearn.txt
+++ b/envs/requirements-sklearn.txt
@@ -8,7 +8,7 @@ scikit-learn-intelex
 dpctl
 dpnp
 # sklbench dependencies
-scikit-learn
+scikit-learn>=1.8
 pandas
 tabulate
 fastparquet

--- a/sklbench/benchmarks/estimator_task_map.json
+++ b/sklbench/benchmarks/estimator_task_map.json
@@ -2,6 +2,7 @@
     "classification": [
         "Classifier",
         "LogisticRegression",
+        "LogisticRegressionCV",
         "SVC"
     ],
     "regression": [


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation PR(s) if needed
-->

Adds a small config checking LogisticRegressionCV, which was recently added to sklearnex: https://github.com/uxlfoundation/scikit-learn-intelex/pull/2871

Since it executes the same code as LogisticRegression, I'm adding only a very small example so as not to increase running times too much.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
