### PR TITLE
Remove uneeded code and dependencies

### DIFF
--- a/envs/conda-env-rapids.yml
+++ b/envs/conda-env-rapids.yml
@@ -10,8 +10,7 @@ dependencies:
   # sklbench dependencies
   - scikit-learn
   - pandas
-  - tabulate
-  - fastparquet
+  - pyarrow
   - h5py
   - openpyxl
   - tqdm

--- a/envs/conda-env-sklearn.yml
+++ b/envs/conda-env-sklearn.yml
@@ -6,14 +6,11 @@ dependencies:
   - xgboost
   - catboost
   - lightgbm
-  - faiss-cpu
-  - modin-all
   - scikit-learn-intelex
   # sklbench dependencies
   - scikit-learn
   - pandas
-  - tabulate
-  - fastparquet
+  - pyarrow
   - h5py
   - openpyxl
   - tqdm

--- a/envs/requirements-sklearn.txt
+++ b/envs/requirements-sklearn.txt
@@ -2,16 +2,13 @@
 xgboost
 catboost
 lightgbm
-faiss-cpu
-modin[all]
 scikit-learn-intelex
 dpctl
 dpnp
 # sklbench dependencies
 scikit-learn
 pandas
-tabulate
-fastparquet
+pyarrow
 h5py
 openpyxl
 tqdm

--- a/sklbench/datasets/common.py
+++ b/sklbench/datasets/common.py
@@ -101,7 +101,7 @@ def save_data_to_cache(data: Dict, data_cache: str, data_name: str):
                 for column in list(data_compoment.columns)
             ]
             data_compoment.to_parquet(
-                component_filepath, engine="fastparquet", compression="snappy"
+                component_filepath
             )
         elif isinstance(data_compoment, csr_matrix):
             component_filepath += ".csr.npz"

--- a/sklbench/datasets/transformer.py
+++ b/sklbench/datasets/transformer.py
@@ -57,24 +57,6 @@ def convert_data(data, dformat: str, order: str, dtype: str, device: str = None)
         import dpctl.tensor
 
         return dpctl.tensor.asarray(data, dtype=dtype, order=order, device=device)
-    elif dformat.startswith("modin"):
-        if dformat.endswith("ray"):
-            os.environ["MODIN_ENGINE"] = "ray"
-        elif dformat.endswith("dask"):
-            os.environ["MODIN_ENGINE"] = "dask"
-        elif dformat.endswith("unidist"):
-            os.environ["MODIN_ENGINE"] = "unidist"
-            os.environ["UNIDIST_BACKEND"] = "mpi"
-        else:
-            logger.info(
-                "Modin engine is unknown or not specified. Default engine will be used."
-            )
-
-        import modin.pandas as modin_pd
-
-        if data.ndim == 1:
-            return modin_pd.Series(data)
-        return modin_pd.DataFrame(data)
     elif dformat == "cudf":
         import cudf
 


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation PR(s) if needed
-->

There is some code trying to deal with moding objects, but those are not used anywhere and it's not clear if it even works. Since moding is not used in any existing configuration, is not a popular library, and is generally not directly supported by scikit-learn, this PR removes both the code and the library dependency on it, which allows to eliminate other transitive dependencies.

Along the way, it also updates pandas parquet code to use pyarrow instead, which is a more commonplace library than `fastparquet` and is their default choice. As of pandas3, this explicit dependency on arrow could potentially be dropped since they will have some arrow-related dependencies being mandatory.

The PR also drops the dependency on `tabulate` as it doesn't appear to be used anywhere in the code or CI scripts, and drops the dependency on FAISS since there are currently no benchmarks for it.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
