### PR TITLE
Fix prefetch-dataset hang on GPU

### DIFF
--- a/sklbench/runner/implementation.py
+++ b/sklbench/runner/implementation.py
@@ -17,7 +17,7 @@
 
 import argparse
 import json
-from multiprocessing import Pool
+from multiprocessing import get_context
 from typing import Dict, List, Tuple, Union
 
 from psutil import cpu_count
@@ -102,7 +102,7 @@ def run_benchmarks(args: argparse.Namespace) -> int:
         logger.debug(f"Unique dataset names to load:\n{list(dataset_cases.keys())}")
         n_proc = min([16, cpu_count(), n_datasets])
         logger.info(f"Prefetching {n_datasets} datasets with {n_proc} processes")
-        with Pool(n_proc) as pool:
+        with get_context("spawn").Pool(n_proc) as pool:
             pool.map(load_data_with_cleanup, dataset_cases.values())
 
     # run bench_cases

--- a/sklbench/runner/implementation.py
+++ b/sklbench/runner/implementation.py
@@ -17,7 +17,7 @@
 
 import argparse
 import json
-from multiprocessing import get_context
+from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Tuple, Union
 
 from psutil import cpu_count
@@ -102,8 +102,8 @@ def run_benchmarks(args: argparse.Namespace) -> int:
         logger.debug(f"Unique dataset names to load:\n{list(dataset_cases.keys())}")
         n_proc = min([16, cpu_count(), n_datasets])
         logger.info(f"Prefetching {n_datasets} datasets with {n_proc} processes")
-        with get_context("spawn").Pool(n_proc) as pool:
-            pool.map(load_data_with_cleanup, dataset_cases.values())
+        with ThreadPoolExecutor(max_workers=n_proc) as executor:
+            list(executor.map(load_data_with_cleanup, dataset_cases.values()))
 
     # run bench_cases
     return_code, result = call_benchmarks(


### PR DESCRIPTION
## Description

Dataset prefetching with --prefetch-datasets was hanging all subsequent GPU benchmarks because multiprocessing.Pool defaults to fork, which corrupts the SYCL/Level Zero GPU runtime when child processes exit. Switched to spawn start method to avoid this.

Still more work needed on this

Via claude

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

</details>
