### PR TITLE
Fix pandas3 compat: use pd.Series(...).value_counts() instead of pd.value_counts(...)

### DIFF
--- a/sklbench/datasets/loaders.py
+++ b/sklbench/datasets/loaders.py
@@ -42,8 +42,8 @@ def load_openml_data(
 ) -> Tuple[Dict, Dict]:
     x, y = load_openml(openml_id, raw_data_cache)
     data_desc = dict()
-    unique_labels = dict(pd.value_counts(y))
-    if len(unique_labels) < 32 and all(map(lambda x: x > 4, unique_labels.values())):
+    unique_labels = pd.Series(y).value_counts()
+    if len(unique_labels) < 32 and (unique_labels > 4).all():
         data_desc["n_classes"] = len(unique_labels)
     return {"x": x, "y": y}, data_desc
 

--- a/sklbench/utils/special_params.py
+++ b/sklbench/utils/special_params.py
@@ -214,7 +214,7 @@ def assign_case_special_values_on_run(
         and estimator.endswith("Classifier")
     ):
         y_train = convert_to_numpy(data[1])
-        value_counts = pd.value_counts(y_train).sort_index()
+        value_counts = pd.Series(y_train).value_counts().sort_index()
         if len(value_counts) != 2:
             logger.info(
                 f"Number of classes ({len(value_counts)}) != 2 "


### PR DESCRIPTION
## Description

pandas 3 stopped exposing `pd.value_counts` so a couple of places were breaking. I changed to using `pd.Series(...).value_counts()` instead.

---


<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.

</details>
