### PR TITLE
Calculate number of nodes in the tree estimators

### DIFF
--- a/sklbench/benchmarks/sklearn_estimator.py
+++ b/sklbench/benchmarks/sklearn_estimator.py
@@ -134,6 +134,16 @@ def get_subset_metrics_of_estimator(
                 and isinstance(iterations[0], Union[Numeric, NumpyNumeric].__args__)
             ):
                 metrics.update({"iterations": int(iterations[0])})
+        if hasattr(estimator_instance, "estimators_"):
+            estimators_with_trees = [
+                t
+                for t in estimator_instance.estimators_
+                if hasattr(t, "tree_") and hasattr(t.tree_, "node_count")
+            ]
+            if estimators_with_trees:
+                metrics["n_nodes"] = sum(
+                    t.tree_.node_count for t in estimators_with_trees
+                )
     if task == "classification":
         y_pred = convert_to_numpy(estimator_instance.predict(x))
         metrics.update(

--- a/sklbench/report/implementation.py
+++ b/sklbench/report/implementation.py
@@ -71,6 +71,8 @@ METRICS = {
         # NB: 'n_clusters' is parameter of KMeans while
         # 'clusters' is number of computer clusters by DBSCAN
         "clusters",
+        # tree ensembles
+        "n_nodes",
     ],
     "incomparable": [
         "1st-mean run ratio",


### PR DESCRIPTION
## Description

- Automatically report total number of tree nodes (`n_nodes`) for Random Forest and Extra Trees estimators after training
- Register `n_nodes` as an indifferent metric in the report so it's compared across libraries rather than treated as a grouping parameter

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

</details>
