### PR TITLE
Return SVR year_prediction_msd dataset into regular testing scope

### DIFF
--- a/configs/regular/svm.json
+++ b/configs/regular/svm.json
@@ -37,7 +37,10 @@
         ],
         "svr datasets": [
             {
-                "data": { "dataset": "year_prediction_msd", "split_kwargs": { "train_size": 20000, "test_size": null } },
+                "data": {
+                    "dataset": "year_prediction_msd",
+                    "split_kwargs": { "train_size": 20000, "test_size": null }
+                },
                 "algorithm": { "estimator_params": { "C": 0.01, "kernel": "rbf" } }
             },
             {

--- a/configs/regular/svm.json
+++ b/configs/regular/svm.json
@@ -37,6 +37,10 @@
         ],
         "svr datasets": [
             {
+                "data": { "dataset": "year_prediction_msd", "split_kwargs": { "train_size": 20000, "test_size": null } },
+                "algorithm": { "estimator_params": { "C": 0.01, "kernel": "rbf" } }
+            },
+            {
                 "data": { "dataset": "fried", "split_kwargs": { "train_size": 0.5, "test_size": 0.5 } },
                 "algorithm": { "estimator_params": { "C": 2.0, "kernel": "rbf" } }
             },

--- a/configs/weekly/svm.json
+++ b/configs/weekly/svm.json
@@ -39,7 +39,7 @@
                     "dataset": "year_prediction_msd",
                     "split_kwargs": { "train_size": 50000, "test_size": null }
                 },
-                "algorithm": { "estimator_params": { "C": 1.0, "kernel": "rbf" } }
+                "algorithm": { "estimator_params": { "C": 0.01, "kernel": "rbf" } }
             },
             {
                 "data": { "dataset": "twodplanes", "split_kwargs": { "ignore": true } },
@@ -78,7 +78,7 @@
                     "dataset": "year_prediction_msd",
                     "split_kwargs": { "train_size": 50000, "test_size": null }
                 },
-                "algorithm": { "estimator_params": { "C": 1.0, "kernel": "rbf" } }
+                "algorithm": { "estimator_params": { "C": 0.01, "kernel": "rbf" } }
             },
             {
                 "data": { "dataset": "twodplanes", "split_kwargs": { "ignore": true } },


### PR DESCRIPTION
## Description

SVR testing was hanging previously on year_prediction_msd dataset because C variable was chosen incorrectly.
C was changed from 1.0 to 0.01 for this dataset, so now SVR takes 21 iterations to converge instead of 10000 (maximum number of iterations).

---
<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
