### PR TITLE
Guard n_jobs access after conditional column drop

### DIFF
--- a/sklbench/report/compatibility.py
+++ b/sklbench/report/compatibility.py
@@ -50,7 +50,7 @@ def transform_results_to_compatible(results: pd.DataFrame):
             ],
         )
         # auto-assigned `n_jobs` drop for different CPUs
-        if results["n_jobs"].unique().size > 1:
+        if "n_jobs" in results.columns and results["n_jobs"].unique().size > 1:
             results.drop(
                 inplace=True,
                 errors="ignore",


### PR DESCRIPTION
## Description

Fixes a crash in `--compatibility-mode` report generation introduced by #219.

#219 added a block that drops the `n_jobs` column when it is partially NaN:

```python
if (
    "n_jobs" in results.columns
    and results["n_jobs"].isna().any()
    and results["n_jobs"].notna().any()
):
    results.drop(inplace=True, columns=["n_jobs"])
```

The pre-existing access below it (added in #184) was left unguarded, so once
the column is dropped, `transform_results_to_compatible` raises
`KeyError: 'n_jobs'`.

Three conditions are needed to trigger it, which is why it wasn't caught:

1. `--compatibility-mode` — the only caller of `transform_results_to_compatible`
2. `n_jobs` partially NaN, so the new block drops it. True for any full-suite
   run, since `LinearRegression`/kNN/ensemble carry `n_jobs` while `Ridge`/
   `Lasso`/`ElasticNet` do not.
3. More than one `environment_name` — true when comparing a measurements file
   against a baseline captured on another environment.

Observed on a nightly benchmark report comparing current SPR measurements
against the `sklearnex_performance_SPR_2026.1.0` baseline.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
