### PR TITLE
re-add preview for lasso/enet

### DIFF
--- a/configs/common/sklearn.json
+++ b/configs/common/sklearn.json
@@ -18,6 +18,12 @@
                 "data": { "format": "dpnp", "order": "C" }
             }
         ],
+        "sklearn-ex[preview,cpu] implementations": {
+            "algorithm": [
+                { "library": "sklearn", "device": "cpu" },
+                { "library": "sklearnex.preview", "device": "cpu" }
+            ]
+        },
         "sklearnex spmd implementation": {
             "algorithm": {
                 "library": "sklearnex.spmd",

--- a/configs/regular/linear_model.json
+++ b/configs/regular/linear_model.json
@@ -61,10 +61,10 @@
             ]
         },
         "sklearn lasso": {
-            "SETS": ["sklearn-ex[cpu] implementations", "common lasso parameters", "regression datasets"]
+            "SETS": ["sklearn-ex[preview,cpu] implementations", "common lasso parameters", "regression datasets"]
         },
         "sklearn elasticnet": {
-            "SETS": ["sklearn-ex[cpu] implementations", "common elasticnet parameters", "regression datasets"]
+            "SETS": ["sklearn-ex[preview,cpu] implementations", "common elasticnet parameters", "regression datasets"]
         },
         "cuml linear": {
             "SETS": ["cuml implementation", "common linear parameters", "cuml L2 parameters", "regression datasets"]

--- a/configs/testing/azure-pipelines-ci.json
+++ b/configs/testing/azure-pipelines-ci.json
@@ -91,7 +91,7 @@
             },
             {
                 "algorithm": {
-                    "estimator": ["LinearRegression", "Ridge", "Lasso", "ElasticNet"]
+                    "estimator": ["LinearRegression", "Ridge"]
                 }
             },
             {
@@ -116,11 +116,27 @@
                     }
                 }
             }
+        ],
+        "preview algorithms": [
+            {
+                "algorithm": {
+                    "estimator": ["Lasso", "ElasticNet"]
+                }
+            }
         ]
     },
     "TEMPLATES": {
         "test": {
             "SETS": ["sklearn-ex[cpu] implementations", "common parameters", "data formats", "datasets", "algorithms"]
+        },
+        "test preview": {
+            "SETS": [
+                "sklearn-ex[preview,cpu] implementations",
+                "common parameters",
+                "data formats",
+                "datasets",
+                "preview algorithms"
+            ]
         }
     }
 }

--- a/configs/weekly/linear_model.json
+++ b/configs/weekly/linear_model.json
@@ -57,10 +57,10 @@
             ]
         },
         "sklearn lasso": {
-            "SETS": ["sklearn-ex[cpu] implementations", "common lasso parameters", "regression datasets"]
+            "SETS": ["sklearn-ex[preview,cpu] implementations", "common lasso parameters", "regression datasets"]
         },
         "sklearn elasticnet": {
-            "SETS": ["sklearn-ex[cpu] implementations", "common elasticnet parameters", "regression datasets"]
+            "SETS": ["sklearn-ex[preview,cpu] implementations", "common elasticnet parameters", "regression datasets"]
         },
         "cuml linear": {
             "SETS": ["cuml implementation", "common linear parameters", "cuml L2 parameters", "regression datasets"]

--- a/sklbench/report/compatibility.py
+++ b/sklbench/report/compatibility.py
@@ -50,7 +50,7 @@ def transform_results_to_compatible(results: pd.DataFrame):
             ],
         )
         # auto-assigned `n_jobs` drop for different CPUs
-        if results["n_jobs"].unique().size > 1:
+        if "n_jobs" in results.columns and results["n_jobs"].unique().size > 1:
             results.drop(
                 inplace=True,
                 errors="ignore",


### PR DESCRIPTION
## Description

Ref: https://github.com/IntelPython/scikit-learn_bench/pull/168, https://github.com/IntelPython/scikit-learn_bench/pull/185, https://github.com/uxlfoundation/scikit-learn-intelex/pull/3418

CI on main: http://intel-ci.intel.com/f1a99f30-60cb-f12e-bffe-724646f3d540
CI on this branch without #223: http://intel-ci.intel.com/f1aca544-6b9a-f1c2-935d-724646f3d540
CI on this branch current state with #223: http://intel-ci.intel.com/f1acc416-9050-f195-aecb-724646f3d540

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

</details>



---

**Depends on #223** (`n_jobs` KeyError fix). That commit is included in this branch so CI can pass; it will drop out of this diff once #223 merges and this branch is rebased.
